### PR TITLE
Remove dependency of System.Runtime.Serialization.dll

### DIFF
--- a/src/MsgPack.Mono/MsgPack.Mono.csproj
+++ b/src/MsgPack.Mono/MsgPack.Mono.csproj
@@ -41,7 +41,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/MsgPack.Net35/MsgPack.Net35.csproj
+++ b/src/MsgPack.Net35/MsgPack.Net35.csproj
@@ -43,7 +43,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/MsgPack.Serialization.Silverlight.4/MsgPack.Serialization.Silverlight.4.csproj
+++ b/src/MsgPack.Serialization.Silverlight.4/MsgPack.Serialization.Silverlight.4.csproj
@@ -57,7 +57,6 @@
     <Reference Include="System.Numerics, Version=2.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="system" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows" />

--- a/src/MsgPack.Serialization.Silverlight.5/MsgPack.Serialization.Silverlight.5.csproj
+++ b/src/MsgPack.Serialization.Silverlight.5/MsgPack.Serialization.Silverlight.5.csproj
@@ -56,7 +56,6 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System.Numerics, Version=5.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows" />
     <Reference Include="system" />
     <Reference Include="System.Core" />

--- a/src/MsgPack.Serialization.WindowsPhone.7.1/MsgPack.Serialization.WindowsPhone.7.1.csproj
+++ b/src/MsgPack.Serialization.WindowsPhone.7.1/MsgPack.Serialization.WindowsPhone.7.1.csproj
@@ -42,7 +42,6 @@
     <DocumentationFile>..\..\bin\sl4-windowsphone71\MsgPack.Serialization.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows" />
     <Reference Include="system" />
     <Reference Include="System.Core" />

--- a/src/MsgPack/MsgPack.csproj
+++ b/src/MsgPack/MsgPack.csproj
@@ -91,7 +91,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/MsgPack/Serialization/DataMemberContract.cs
+++ b/src/MsgPack/Serialization/DataMemberContract.cs
@@ -97,25 +97,31 @@ namespace MsgPack.Serialization
 		}
 
 		/// <summary>
-		///		Initializes a new instance of the <see cref="DataMemberContract"/> struct from <see cref="DataMemberAttribute"/>.
+		///		Initializes a new instance of the <see cref="DataMemberContract"/> struct.
 		/// </summary>
 		/// <param name="member">The target member.</param>
-		/// <param name="attribute">The data contract member attribute. This value can be <c>null</c>.</param>
-		public DataMemberContract( MemberInfo member, DataMemberAttribute attribute )
+		/// <param name="name">The name of member.</param>
+		/// <param name="nilImplication">The implication of the nil value for the member.</param>
+		/// <param name="id">The ID of the member. This value cannot be negative and must be unique in the type.</param>
+		public DataMemberContract( MemberInfo member, string name, NilImplication nilImplication, int? id )
 		{
 			Contract.Requires( member != null );
-			Contract.Requires( attribute != null );
 
-			this._name = String.IsNullOrEmpty( attribute.Name ) ? member.Name : attribute.Name;
-			this._nilImplication = Serialization.NilImplication.MemberDefault;
-			this._id = attribute.Order;
+			if ( id < 0 )
+			{
+				throw new SerializationException( String.Format( CultureInfo.CurrentCulture, "The member ID cannot be negative. The member is '{0}' in the '{1}' type.", member.Name, member.DeclaringType ) );
+			}
+
+			this._name = String.IsNullOrEmpty( name ) ? member.Name : name;
+			this._nilImplication = nilImplication;
+			this._id = id ?? UnspecifiedId;
 		}
 
 		/// <summary>
 		///		Initializes a new instance of the <see cref="DataMemberContract"/> struct from <see cref="MessagePackMemberAttribute"/>.
 		/// </summary>
 		/// <param name="member">The target member.</param>
-		/// <param name="attribute">The MessagePack member attribute. This value can be <c>null</c>.</param>
+		/// <param name="attribute">The MessagePack member attribute.</param>
 		public DataMemberContract( MemberInfo member, MessagePackMemberAttribute attribute )
 		{
 			Contract.Requires( member != null );


### PR DESCRIPTION
## Overview
- Remove assembly references to `System.Runtime.Serialization`.
- Re-implement the codes to test `DataContractAttribute` and `DataMemberAttribute` with reflection rather than static member access.
- This also may be able to apply for the branch `0.5`.
## Purpose
- The dependency of `System.Runtime.Serialization` is only for compatibility for other serializer, but this causes loading `System.Runtime.Serialization` assembly. I think this is a bit wasteful.
## Concerns
- It ran on my environment but it is not fully-tested.
