### PR TITLE
Fixes crash on certain streams if the size is 0

### DIFF
--- a/src/MsgPack/ItemsUnpacker.Unpacking.cs
+++ b/src/MsgPack/ItemsUnpacker.Unpacking.cs
@@ -7343,14 +7343,17 @@ namespace MsgPack
 					var size = header & 0x1F;
 					var resultValue = new byte[ size ];
 					#region UnpackRawContent
-					
-					var bytesRead = source.Read( resultValue, 0, size );
-					if( bytesRead < size )
-					{
-						throw new InvalidMessagePackStreamException( "Stream unexpectedly ends." );
-					}
-					
-					#endregion UnpackRawContent
+
+				    if (size > 0)
+				    {
+				        var bytesRead = source.Read(resultValue, 0, size);
+				        if (bytesRead < size)
+				        {
+				            throw new InvalidMessagePackStreamException("Stream unexpectedly ends.");
+				        }
+				    }
+
+				    #endregion UnpackRawContent
 					var resultMpoValue = new MessagePackObject( new MessagePackString( resultValue, false ) );
 					this.InternalCollectionType = CollectionType.None;
 					result = resultMpoValue;


### PR DESCRIPTION
You can read 0 bytes from a MemoryStream or a FileStream, however a
System.Net.Http.StreamContent.ReadOnlyStream (used in WebApi) throws a
System.InvalidOperationException, if you try and read 0 bytes.