### PR TITLE
Add MessagePackIgnoreAttribute to exclude properties. Issue #55

### DIFF
--- a/src/MsgPack.Net35/MsgPack.Net35.csproj
+++ b/src/MsgPack.Net35/MsgPack.Net35.csproj
@@ -521,6 +521,9 @@
     <Compile Include="..\MsgPack\Serialization\MessagePackEnumMemberAttribute.cs">
       <Link>Serialization\MessagePackEnumMemberAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\MsgPack\Serialization\MessagePackIgnoreAttribute.cs">
+      <Link>Serialization\MessagePackIgnoreAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\MsgPack\Serialization\MessagePackMemberAttribute.cs">
       <Link>Serialization\MessagePackMemberAttribute.cs</Link>
     </Compile>

--- a/src/MsgPack.Net40/MsgPack.Net40.csproj
+++ b/src/MsgPack.Net40/MsgPack.Net40.csproj
@@ -532,6 +532,9 @@
     <Compile Include="..\MsgPack\Serialization\MessagePackEnumMemberAttribute.cs">
       <Link>Serialization\MessagePackEnumMemberAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\MsgPack\Serialization\MessagePackIgnoreAttribute.cs">
+      <Link>Serialization\MessagePackIgnoreAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\MsgPack\Serialization\MessagePackMemberAttribute.cs">
       <Link>Serialization\MessagePackMemberAttribute.cs</Link>
     </Compile>

--- a/src/MsgPack.Silverlight.5/MsgPack.Silverlight.5.csproj
+++ b/src/MsgPack.Silverlight.5/MsgPack.Silverlight.5.csproj
@@ -523,6 +523,9 @@
     <Compile Include="..\MsgPack\Serialization\MessagePackEnumMemberAttribute.cs">
       <Link>Serialization\MessagePackEnumMemberAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\MsgPack\Serialization\MessagePackIgnoreAttribute.cs">
+      <Link>Serialization\MessagePackIgnoreAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\MsgPack\Serialization\MessagePackMemberAttribute.cs">
       <Link>Serialization\MessagePackMemberAttribute.cs</Link>
     </Compile>

--- a/src/MsgPack.Silverlight.WindowsPhone/MsgPack.Silverlight.WindowsPhone.csproj
+++ b/src/MsgPack.Silverlight.WindowsPhone/MsgPack.Silverlight.WindowsPhone.csproj
@@ -481,6 +481,9 @@
     <Compile Include="..\MsgPack\Serialization\MessagePackEnumMemberAttribute.cs">
       <Link>Serialization\MessagePackEnumMemberAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\MsgPack\Serialization\MessagePackIgnoreAttribute.cs">
+      <Link>Serialization\MessagePackIgnoreAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\MsgPack\Serialization\MessagePackMemberAttribute.cs">
       <Link>Serialization\MessagePackMemberAttribute.cs</Link>
     </Compile>

--- a/src/MsgPack.Unity3D/MsgPack.Unity3D.csproj
+++ b/src/MsgPack.Unity3D/MsgPack.Unity3D.csproj
@@ -363,6 +363,9 @@
     <Compile Include="..\MsgPack\Serialization\MessagePackEnumMemberAttribute.cs">
       <Link>Serialization\MessagePackEnumMemberAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\MsgPack\Serialization\MessagePackIgnoreAttribute.cs">
+      <Link>Serialization\MessagePackIgnoreAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\MsgPack\Serialization\MessagePackMemberAttribute.cs">
       <Link>Serialization\MessagePackMemberAttribute.cs</Link>
     </Compile>

--- a/src/MsgPack.WinRT.Portable/MsgPack.WinRT.Portable.csproj
+++ b/src/MsgPack.WinRT.Portable/MsgPack.WinRT.Portable.csproj
@@ -424,6 +424,9 @@
     <Compile Include="..\MsgPack\Serialization\MessagePackEnumMemberAttribute.cs">
       <Link>Serialization\MessagePackEnumMemberAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\MsgPack\Serialization\MessagePackIgnoreAttribute.cs">
+      <Link>Serialization\MessagePackIgnoreAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\MsgPack\Serialization\MessagePackMemberAttribute.cs">
       <Link>Serialization\MessagePackMemberAttribute.cs</Link>
     </Compile>

--- a/src/MsgPack.Xamarin.Android/MsgPack.Xamarin.Android.csproj
+++ b/src/MsgPack.Xamarin.Android/MsgPack.Xamarin.Android.csproj
@@ -355,6 +355,9 @@
     <Compile Include="..\MsgPack\Serialization\MessagePackEnumMemberAttribute.cs">
       <Link>Serialization\MessagePackEnumMemberAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\MsgPack\Serialization\MessagePackIgnoreAttribute.cs">
+      <Link>Serialization\MessagePackIgnoreAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\MsgPack\Serialization\MessagePackMemberAttribute.cs">
       <Link>Serialization\MessagePackMemberAttribute.cs</Link>
     </Compile>

--- a/src/MsgPack.Xamarin.iOS/MsgPack.Xamarin.iOS.csproj
+++ b/src/MsgPack.Xamarin.iOS/MsgPack.Xamarin.iOS.csproj
@@ -359,6 +359,9 @@
     <Compile Include="..\MsgPack\Serialization\MessagePackEnumMemberAttribute.cs">
       <Link>Serialization\MessagePackEnumMemberAttribute.cs</Link>
     </Compile>
+    <Compile Include="..\MsgPack\Serialization\MessagePackIgnoreAttribute.cs">
+      <Link>Serialization\MessagePackIgnoreAttribute.cs</Link>
+    </Compile>
     <Compile Include="..\MsgPack\Serialization\MessagePackMemberAttribute.cs">
       <Link>Serialization\MessagePackMemberAttribute.cs</Link>
     </Compile>

--- a/src/MsgPack/MsgPack.csproj
+++ b/src/MsgPack/MsgPack.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Serialization\CollectionDetailedKind.cs" />
     <Compile Include="Serialization\INilImplicationHandlerOnUnpackedParameter.cs" />
     <Compile Include="Serialization\INilImplicationHandlerParameter.cs" />
+    <Compile Include="Serialization\MessagePackIgnoreAttribute.cs" />
     <Compile Include="Serialization\NilImplicationHandler`4.cs" />
     <Compile Include="Serialization\ReflectionSerializers\ReflectionCollectionSerializer.cs" />
     <Compile Include="Serialization\ReflectionSerializers\ReflectionNilImplicationHandler.cs" />

--- a/src/MsgPack/Serialization/MessagePackIgnoreAttribute.cs
+++ b/src/MsgPack/Serialization/MessagePackIgnoreAttribute.cs
@@ -1,0 +1,39 @@
+﻿#region -- License Terms --
+//
+// MessagePack for CLI
+//
+// Copyright (C) 2014 FUJIWARA, Yusuke
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// Contributors:
+//    Takeshi KIRIYA
+//
+#endregion -- License Terms --
+
+using System;
+
+namespace MsgPack.Serialization
+{
+	/// <summary>
+	///		Marks the field or the property should not be serialized/deserialized with MessagePack for CLI serialization mechanism.
+	/// </summary>
+	[AttributeUsage( AttributeTargets.Field | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+	public sealed class MessagePackIgnoreAttribute : Attribute
+	{
+		/// <summary>
+		///		Initializes a new instance of the <see cref="MessagePackIgnoreAttribute"/> class.
+		/// </summary>
+		public MessagePackIgnoreAttribute() { }
+	}
+}

--- a/src/MsgPack/Serialization/SerializationTarget.cs
+++ b/src/MsgPack/Serialization/SerializationTarget.cs
@@ -137,6 +137,28 @@ namespace MsgPack.Serialization
 
 			if ( filtered.Length > 0 )
 			{
+				var duplicated =
+					filtered.FirstOrDefault(
+						member =>
+#if !NETFX_CORE
+							Attribute.IsDefined( member, typeof( MessagePackIgnoreAttribute ) )
+#else
+							member.IsDefined( typeof( MessagePackIgnoreAttribute ) ) 
+#endif // !NETFX_CORE
+					);
+
+				if ( duplicated != null )
+				{
+					throw new SerializationException(
+						String.Format(
+							CultureInfo.CurrentCulture,
+							"A member '{0}' of type '{1}' is marked with both MessagePackMemberAttribute and MessagePackIgnoreAttribute.",
+							duplicated.Name,
+							type 
+						)
+					);
+				}
+
 				return
 					filtered.Select( member =>
 						new SerializingMember(
@@ -187,13 +209,18 @@ namespace MsgPack.Serialization
 						}
 					);
 			}
-#if SILVERLIGHT || NETFX_CORE
-			return members.Where( member => member.GetIsPublic() ).Select( member => new SerializingMember( member, new DataMemberContract( member ) ) );
-#else
 			return
-				members.Where( item => item.GetIsPublic() && !Attribute.IsDefined( item, typeof( NonSerializedAttribute ) ) )
-				.Select( member => new SerializingMember( member, new DataMemberContract( member ) ) );
-#endif
+				members.Where(
+					member => member.GetIsPublic()
+#if !SILVERLIGHT && !NETFX_CORE
+					&& !Attribute.IsDefined( member, typeof( NonSerializedAttribute ) )
+#endif // !SILVERLIGHT && !NETFX_CORE
+#if !NETFX_CORE
+					&& !Attribute.IsDefined( member, typeof( MessagePackIgnoreAttribute ) )
+#else
+					&& !member.IsDefined( typeof( MessagePackIgnoreAttribute ) ) 
+#endif // !NETFX_CORE
+				).Select( member => new SerializingMember( member, new DataMemberContract( member ) ) );
 		}
 
 		private static bool CheckTargetEligibility( MemberInfo member )

--- a/test/MsgPack.UnitTest.CodeDom/Serialization/ArrayCodeDomBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest.CodeDom/Serialization/ArrayCodeDomBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest.CodeDom/Serialization/MapCodeDomBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest.CodeDom/Serialization/MapCodeDomBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/ArrayContextBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/ArrayContextBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/ArrayExpressionBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/ArrayExpressionBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/ArrayFieldBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/ArrayFieldBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/ArrayReflectionBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/ArrayReflectionBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/AutoMessagePackSerializerTest.ttinclude
+++ b/test/MsgPack.UnitTest/Serialization/AutoMessagePackSerializerTest.ttinclude
@@ -1288,6 +1288,129 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+<#+
+	if ( !forIos )
+	{
+#>
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
+<#+
+	}
+#>
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/MapContextBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/MapContextBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/MapExpressionBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/MapExpressionBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/MapFieldBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/MapFieldBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";

--- a/test/MsgPack.UnitTest/Serialization/MapReflectionBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/MapReflectionBasedAutoMessagePackSerializerTest.cs
@@ -1178,6 +1178,122 @@ namespace MsgPack.Serialization
 
 #endregion -- ReadOnly / Private Members --
 
+#region -- Exclusion --
+
+		private void TestIgnoreCore<T>( Action<T> setter, Action<T, T> assertion )
+			where T : new()
+		{
+			var target = GetSerializationContext().GetSerializer<T>();
+			var obj = new T();
+			setter( obj );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, obj );
+				buffer.Position = 0;
+				var actual = target.Unpack( buffer );
+				assertion( obj, actual );
+			}
+		}
+
+		private void TestIgnoreCore<T, TException>()
+			where TException : Exception
+		{
+			Assert.Throws<TException>( () => GetSerializationContext().GetSerializer<T>() );
+		}
+
+		[Test]
+		public void TestIgnore_Normal()
+		{
+			TestIgnoreCore<Excluded>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotIgnored = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotIgnored, Is.EqualTo( expected.NotIgnored ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExcludedOnly()
+		{
+			TestIgnoreCore<OnlyExcluded, SerializationException>();
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionMixed()
+		{
+			TestIgnoreCore<ExclusionAndInclusionMixed>( 
+				target => { 
+					target.IgnoredField = "ABC";
+					target.IgnoredProperty = "ABC";
+					target.NotMarked = "ABC";
+					target.Marked = "ABC";
+				},
+				( expected, actual ) =>
+				{
+					Assert.That( actual.IgnoredField, Is.Null );
+					Assert.That( actual.IgnoredProperty, Is.Null );
+					Assert.That( actual.NotMarked, Is.Null );
+					Assert.That( actual.Marked, Is.EqualTo( expected.Marked ) );
+				}
+			);
+		}
+
+		[Test]
+		public void TestIgnore_ExclusionAndInclusionSimulatously()
+		{
+			TestIgnoreCore<ExclusionAndInclusionSimulatously, SerializationException>();
+		}
+
+
+		public class OnlyExcluded
+		{
+			[MessagePackIgnore]
+			public string Ignored { get; set; }
+		}
+
+		public class Excluded
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotIgnored { get; set; }
+		}
+
+		public class ExclusionAndInclusionMixed
+		{
+			[MessagePackIgnore]
+			public string IgnoredField;
+
+			[MessagePackIgnore]
+			public string IgnoredProperty { get; set; }
+
+			public string NotMarked { get; set; }
+
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+		}
+
+		public class ExclusionAndInclusionSimulatously
+		{
+			[MessagePackMember( 0 )]
+			public string Marked { get; set; }
+
+			[MessagePackIgnore]
+			[MessagePackMember( 1 )]
+			public string DoubleMarked { get; set; }
+		}
+
+#endregion -- Exclusion --
 		public class HasInitOnlyField
 		{
 			public readonly string Field = "ABC";


### PR DESCRIPTION
This is solving our problems with property fields getting serialized; please merge and publish so we can deploy it properly through NuGet. Thanks!