### PR TITLE
Support serialisation of .NET 4.5 read only collection interfaces

### DIFF
--- a/src/MsgPack/Serialization/DefaultConcreteTypeRepository.cs
+++ b/src/MsgPack/Serialization/DefaultConcreteTypeRepository.cs
@@ -47,7 +47,7 @@ namespace MsgPack.Serialization
 #if NETFX_35 || WINDOWS_PHONE
 					8
 #else
-					9
+					12
 #endif
  )
 				{
@@ -61,6 +61,11 @@ namespace MsgPack.Serialization
 					{ typeof( IDictionary ).TypeHandle, typeof( MessagePackObjectDictionary ) },
 #if !NETFX_35 && !UNITY
 					{ typeof( ISet<> ).TypeHandle, typeof( HashSet<> ) },
+#if !NETFX_40
+					{ typeof( IReadOnlyCollection<> ).TypeHandle, typeof( List<> ) },
+					{ typeof( IReadOnlyList<> ).TypeHandle, typeof( List<> ) },
+					{ typeof( IReadOnlyDictionary<,> ).TypeHandle, typeof( Dictionary<,> ) }
+#endif // !NETFX_40
 #endif // !NETFX_35 && !UNITY
 				} );
 		}

--- a/test/MsgPack.UnitTest/Serialization/SerializationContextTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/SerializationContextTest.cs
@@ -99,10 +99,13 @@ namespace MsgPack.Serialization
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( ISet<> ) ), Is.EqualTo( typeof( HashSet<> ) ) );
 #endif
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( ICollection<> ) ), Is.EqualTo( typeof( List<> ) ) );
-			Assert.That( context.DefaultCollectionTypes.Get( typeof( IEnumerable<> ) ), Is.EqualTo( typeof( List<> ) ) );
-			Assert.That( context.DefaultCollectionTypes.Get( typeof( IDictionary<,> ) ), Is.EqualTo( typeof( Dictionary<,> ) ) );
-			Assert.That( context.DefaultCollectionTypes.Get( typeof( IList ) ), Is.EqualTo( typeof( List<MessagePackObject> ) ) );
-			Assert.That( context.DefaultCollectionTypes.Get( typeof( ICollection ) ), Is.EqualTo( typeof( List<MessagePackObject> ) ) );
+		    Assert.That( context.DefaultCollectionTypes.Get( typeof( IReadOnlyCollection<> ) ), Is.EqualTo( typeof( List<> ) ) );
+		    Assert.That( context.DefaultCollectionTypes.Get( typeof( IEnumerable<> ) ), Is.EqualTo( typeof( List<> ) ) );
+		    Assert.That( context.DefaultCollectionTypes.Get( typeof( IDictionary<,> ) ), Is.EqualTo( typeof( Dictionary<,> ) ) );
+		    Assert.That( context.DefaultCollectionTypes.Get( typeof( IReadOnlyDictionary<,> ) ), Is.EqualTo( typeof( Dictionary<,> ) ) );
+		    Assert.That( context.DefaultCollectionTypes.Get( typeof( IList ) ), Is.EqualTo( typeof( List<MessagePackObject> ) ) );
+		    Assert.That( context.DefaultCollectionTypes.Get( typeof( IReadOnlyList<> ) ), Is.EqualTo( typeof( List<> ) ) );
+		    Assert.That( context.DefaultCollectionTypes.Get( typeof( ICollection ) ), Is.EqualTo( typeof( List<MessagePackObject> ) ) );
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( IEnumerable ) ), Is.EqualTo( typeof( List<MessagePackObject> ) ) );
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( IDictionary ) ), Is.EqualTo( typeof( MessagePackObjectDictionary ) ) );
 		}


### PR DESCRIPTION
This is my attempt to close the issue I opened (#91) regarding this feature.

Supported types are:

- `IReadOnlyDictionary<,>`
- `IReadOnlyCollection<>`
- `IReadOnlyList<>`