### PR TITLE
Fix unpack skipping when extra fields are present

### DIFF
--- a/src/MsgPack/ItemsUnpacker.Skipping.tt
+++ b/src/MsgPack/ItemsUnpacker.Skipping.tt
@@ -229,6 +229,21 @@ this.PopIndent();
 #>
 						continue;
 					}
+					case MessagePackCode.Str8:
+					case MessagePackCode.Bin8:
+					{
+						skipped += 1;
+						byte length;
+<#
+this.PushIndent( 6 );
+this.WriteUnpackByte( "length" );
+this.WriteDrainValue( "length" );
+this.WriteTryPopCollection();
+this.PopIndent();
+#>
+						continue;
+					}
+					case MessagePackCode.Bin16:
 					case MessagePackCode.Raw16:
 					{
 						skipped += 1;
@@ -242,6 +257,7 @@ this.PopIndent();
 #>
 						continue;
 					}
+					case MessagePackCode.Bin32:
 					case MessagePackCode.Raw32:
 					{
 						skipped += 1;
@@ -456,6 +472,22 @@ if ( read == <#= size.ToString( CultureInfo.InvariantCulture ) #> )
 {
 	<#= lengthVariable #> = BigEndianBinary.ToUInt<#= ( size * 8 ).ToString( CultureInfo.InvariantCulture ) #>( buffer, 0 );
 	skipped += <#= size #>;
+}
+else
+{
+	return null;
+}
+<#+
+}
+
+private void WriteUnpackByte( string lengthVariable )
+{
+#>
+var read = source.Read( buffer, 0, 1 );
+if ( read == 1 )
+{
+	<#= lengthVariable #> = buffer[0];
+	skipped += 1;
 }
 else
 {

--- a/test/MsgPack.UnitTest/Serialization/VersioningTest.Cases.cs
+++ b/test/MsgPack.UnitTest/Serialization/VersioningTest.Cases.cs
@@ -39,9 +39,9 @@ namespace MsgPack.Serialization
 #if !NETFX_CORE
 
 		[Test]
-		public void TestExtraField_NotExtensible_Array_FieldBased_Fail()
+		public void TestExtraField_NotExtensible_Array_FieldBased_Classic_Fail()
 		{
-			TestExtraFieldCore<VersioningTestTarget>( SerializationMethod.Array, EmitterFlavor.FieldBased );
+			TestExtraFieldCore( SerializationMethod.Array, EmitterFlavor.FieldBased, PackerCompatibilityOptions.Classic );
 		}
 
 		[Test]
@@ -59,9 +59,9 @@ namespace MsgPack.Serialization
 #if !NETFX_CORE
 
 		[Test]
-		public void TestExtraField_NotExtensible_Array_ContextBased_Fail()
+		public void TestExtraField_NotExtensible_Array_ContextBased_Classic_Fail()
 		{
-			TestExtraFieldCore<VersioningTestTarget>( SerializationMethod.Array, EmitterFlavor.ContextBased );
+			TestExtraFieldCore( SerializationMethod.Array, EmitterFlavor.ContextBased, PackerCompatibilityOptions.Classic );
 		}
 
 		[Test]
@@ -79,9 +79,9 @@ namespace MsgPack.Serialization
 #if !NETFX_35
 
 		[Test]
-		public void TestExtraField_NotExtensible_Array_ExpressionBased_Fail()
+		public void TestExtraField_NotExtensible_Array_ExpressionBased_Classic_Fail()
 		{
-			TestExtraFieldCore<VersioningTestTarget>( SerializationMethod.Array, EmitterFlavor.ExpressionBased );
+			TestExtraFieldCore( SerializationMethod.Array, EmitterFlavor.ExpressionBased, PackerCompatibilityOptions.Classic );
 		}
 
 		[Test]
@@ -99,9 +99,15 @@ namespace MsgPack.Serialization
 #if !NETFX_CORE
 
 		[Test]
-		public void TestExtraField_NotExtensible_Map_FieldBased_Fail()
+		public void TestExtraField_NotExtensible_Map_FieldBased_Classic_Fail()
 		{
-			TestExtraFieldCore<VersioningTestTarget>( SerializationMethod.Map, EmitterFlavor.FieldBased );
+			TestExtraFieldCore( SerializationMethod.Map, EmitterFlavor.FieldBased, PackerCompatibilityOptions.Classic );
+		}
+
+		[Test]
+		public void TestExtraField_NotExtensible_Map_FieldBased_None_Fail ()
+		{
+			TestExtraFieldCore( SerializationMethod.Map, EmitterFlavor.FieldBased, PackerCompatibilityOptions.None );
 		}
 
 		[Test]
@@ -125,9 +131,15 @@ namespace MsgPack.Serialization
 #if !NETFX_CORE
 
 		[Test]
-		public void TestExtraField_NotExtensible_Map_ContextBased_Fail()
+		public void TestExtraField_NotExtensible_Map_ContextBased_Classic_Fail()
 		{
-			TestExtraFieldCore<VersioningTestTarget>( SerializationMethod.Map, EmitterFlavor.ContextBased );
+			TestExtraFieldCore( SerializationMethod.Map, EmitterFlavor.ContextBased, PackerCompatibilityOptions.Classic );
+		}
+
+		[Test]
+		public void TestExtraField_NotExtensible_Map_ContextBased_None_Fail ()
+		{
+			TestExtraFieldCore( SerializationMethod.Map, EmitterFlavor.ContextBased, PackerCompatibilityOptions.None );
 		}
 
 		[Test]
@@ -151,9 +163,15 @@ namespace MsgPack.Serialization
 #if !NETFX_35
 
 		[Test]
-		public void TestExtraField_NotExtensible_Map_ExpressionBased_Fail()
+		public void TestExtraField_NotExtensible_Map_ExpressionBased_Classic_Fail()
 		{
-			TestExtraFieldCore<VersioningTestTarget>( SerializationMethod.Map, EmitterFlavor.ExpressionBased );
+			TestExtraFieldCore( SerializationMethod.Map, EmitterFlavor.ExpressionBased, PackerCompatibilityOptions.Classic );
+		}
+
+		[Test]
+		public void TestExtraField_NotExtensible_Map_ExpressionBased_None_Fail ()
+		{
+			TestExtraFieldCore( SerializationMethod.Map, EmitterFlavor.ExpressionBased, PackerCompatibilityOptions.None );
 		}
 
 		[Test]
@@ -174,15 +192,5 @@ namespace MsgPack.Serialization
 			TestFieldSwappedCore( EmitterFlavor.ExpressionBased );
 		}
 #endif // !NETFX_35
-	}
-
-	public class VersioningTestTarget
-	{
-		[MessagePackMember( 0 )]
-		public Int32 Field1 { get; set; }
-		[MessagePackMember( 1 )]
-		public Int32 Field2 { get; set; }
-		[MessagePackMember( 2 )]
-		public String Field3 { get; set; }
 	}
 }


### PR DESCRIPTION
Ensure that unpacker can skip extra fields of type Str8, Bin8, Bin16 and Bin32
which may be present when using PackerCompatibilityOptions.None