### PR TITLE
Allow the serialization of non-collection types implementing IEnumerable

### DIFF
--- a/src/MsgPack/Serialization/AbstractSerializers/SerializerBuilder`2.Collection.cs
+++ b/src/MsgPack/Serialization/AbstractSerializers/SerializerBuilder`2.Collection.cs
@@ -102,7 +102,7 @@ namespace MsgPack.Serialization.AbstractSerializers
 						context, 
 						this.CollectionTraits.AddMethod != null
 						? this.CollectionTraits // For declared collection.
-						: ( concreteType ?? this.TargetType ).GetCollectionTraits( CollectionTraitOptions.Full ) // For concrete collection.
+						: ( concreteType ?? this.TargetType ).GetCollectionTraits( CollectionTraitOptions.Full, context.SerializationContext.CompatibilityOptions.AlwaysAssumeCollections ) // For concrete collection.
 					);
 				}
 			}
@@ -292,7 +292,7 @@ namespace MsgPack.Serialization.AbstractSerializers
 			if ( this.CollectionTraits.CollectionType == CollectionKind.Array && this.CollectionTraits.AddMethod == null )
 			{
 				// Try to use concrete collection's Add.
-				var traitsOfTheCollection = instanceType.GetCollectionTraits( CollectionTraitOptions.Full );
+				var traitsOfTheCollection = instanceType.GetCollectionTraits( CollectionTraitOptions.Full, context.SerializationContext.CompatibilityOptions.AlwaysAssumeCollections );
 
 				bulk =
 					this.MakeNullLiteral(

--- a/src/MsgPack/Serialization/AbstractSerializers/SerializerBuilder`2.CommonConstructs.cs
+++ b/src/MsgPack/Serialization/AbstractSerializers/SerializerBuilder`2.CommonConstructs.cs
@@ -901,7 +901,7 @@ namespace MsgPack.Serialization.AbstractSerializers
 				}
 
 				getCollection = this.EmitGetField( context, instance, asField, !asField.GetHasPublicGetter() );
-				traits = asField.FieldType.GetCollectionTraits( CollectionTraitOptions.Full );
+				traits = asField.FieldType.GetCollectionTraits( CollectionTraitOptions.Full, context.SerializationContext.CompatibilityOptions.AlwaysAssumeCollections );
 			}
 			else
 			{
@@ -916,7 +916,7 @@ namespace MsgPack.Serialization.AbstractSerializers
 				}
 
 				getCollection = this.EmitGetProperty( context, instance, asProperty, !asProperty.GetHasPublicGetter() );
-				traits = asProperty.PropertyType.GetCollectionTraits( CollectionTraitOptions.Full );
+				traits = asProperty.PropertyType.GetCollectionTraits( CollectionTraitOptions.Full, context.SerializationContext.CompatibilityOptions.AlwaysAssumeCollections );
 			}
 
 			var existent = this.DeclareLocal( context, member.GetMemberValueType(), "existent" );

--- a/src/MsgPack/Serialization/CodeDomSerializers/CodeDomContext.cs
+++ b/src/MsgPack/Serialization/CodeDomSerializers/CodeDomContext.cs
@@ -268,7 +268,7 @@ namespace MsgPack.Serialization.CodeDomSerializers
 			this.IndexOfItem = CodeDomConstruct.Parameter( typeof( int ), "indexOfItem" );
 			this.ItemsCount = CodeDomConstruct.Parameter( typeof( int ), "itemsCount" );
 			this.UnpackToTarget = CodeDomConstruct.Parameter( targetType, "collection" );
-			var traits = targetType.GetCollectionTraits( CollectionTraitOptions.Full );
+			var traits = targetType.GetCollectionTraits( CollectionTraitOptions.Full, this.SerializationContext.CompatibilityOptions.AlwaysAssumeCollections );
 			if ( traits.ElementType != null )
 			{
 				this.CollectionToBeAdded = CodeDomConstruct.Parameter( targetType, "collection" );

--- a/src/MsgPack/Serialization/CollectionTraitOptions.cs
+++ b/src/MsgPack/Serialization/CollectionTraitOptions.cs
@@ -29,6 +29,7 @@ namespace MsgPack.Serialization
 		WithAddMethod = 0x1,
 		WithCountPropertyGetter = 0x2,
 		WithGetEnumeratorMethod = 0x4,
-		Full = unchecked( ( int ) 0xFFFFFFFF )
+		ForceCollection = 0x800,
+		Full = WithAddMethod | WithCountPropertyGetter | WithGetEnumeratorMethod
 	}
 }

--- a/src/MsgPack/Serialization/DefaultSerializers/GenericSerializer.cs
+++ b/src/MsgPack/Serialization/DefaultSerializers/GenericSerializer.cs
@@ -309,7 +309,7 @@ namespace MsgPack.Serialization.DefaultSerializers
 					abstractType,
 					concreteType,
 					schema,
-					abstractType.GetCollectionTraits( CollectionTraitOptions.None )
+					abstractType.GetCollectionTraits( CollectionTraitOptions.None, context.CompatibilityOptions.AlwaysAssumeCollections )
 				);
 		}
 

--- a/src/MsgPack/Serialization/EmittingSerializers/AssemblyBuilderEmittingContext.cs
+++ b/src/MsgPack/Serialization/EmittingSerializers/AssemblyBuilderEmittingContext.cs
@@ -108,7 +108,7 @@ namespace MsgPack.Serialization.EmittingSerializers
 			this.IndexOfItem = ILConstruct.Argument( 3, typeof( int ), "indexOfItem" );
 			this.ItemsCount = ILConstruct.Argument( 4, typeof( int ), "itemsCount" );
 			this.UnpackToTarget = ILConstruct.Argument( 2, targetType, "collection" );
-			var traits = targetType.GetCollectionTraits( CollectionTraitOptions.Full );
+			var traits = targetType.GetCollectionTraits( CollectionTraitOptions.Full, this.SerializationContext.CompatibilityOptions.AlwaysAssumeCollections );
 			if ( traits.ElementType != null )
 			{
 				this.CollectionToBeAdded = ILConstruct.Argument( 1, targetType, "collection" );

--- a/src/MsgPack/Serialization/MessagePackSerializer.Factories.cs
+++ b/src/MsgPack/Serialization/MessagePackSerializer.Factories.cs
@@ -224,7 +224,7 @@ namespace MsgPack.Serialization
 #if AOT
 				typeof( T ).GetCollectionTraits( CollectionTraitOptions.None );
 #else
-				typeof( T ).GetCollectionTraits( CollectionTraitOptions.Full );
+				typeof( T ).GetCollectionTraits( CollectionTraitOptions.Full, context.CompatibilityOptions.AlwaysAssumeCollections );
 #endif // AOT
 
 			if ( typeof( T ).GetIsAbstract() || typeof( T ).GetIsInterface() )
@@ -572,9 +572,9 @@ namespace MsgPack.Serialization
 			ValidateType( typeof( T ) );
 			var traits = 
 #if !UNITY
-				typeof( T ).GetCollectionTraits( CollectionTraitOptions.WithAddMethod );
+				typeof( T ).GetCollectionTraits( CollectionTraitOptions.WithAddMethod, forceCollection: true );
 #else
-				typeof( T ).GetCollectionTraits( CollectionTraitOptions.WithAddMethod | CollectionTraitOptions.WithCountPropertyGetter );
+				typeof( T ).GetCollectionTraits( CollectionTraitOptions.WithAddMethod | CollectionTraitOptions.WithCountPropertyGetter, forceCollection: true );
 #endif
 			switch ( traits.CollectionType )
 			{

--- a/src/MsgPack/Serialization/MessagePackSerializer`1.cs
+++ b/src/MsgPack/Serialization/MessagePackSerializer`1.cs
@@ -141,7 +141,7 @@ namespace MsgPack.Serialization
 		private static SerializerCapabilities InferCapatibity()
 		{
 			var result = SerializerCapabilities.PackTo | SerializerCapabilities.UnpackFrom;
-			var traits = typeof( T ).GetCollectionTraits( CollectionTraitOptions.WithAddMethod);
+			var traits = typeof( T ).GetCollectionTraits( CollectionTraitOptions.WithAddMethod, forceCollection: true );
 			if ( traits.AddMethod != null )
 			{
 				result |= SerializerCapabilities.UnpackTo;

--- a/src/MsgPack/Serialization/PolymorphismSchema.Internals.cs
+++ b/src/MsgPack/Serialization/PolymorphismSchema.Internals.cs
@@ -225,7 +225,7 @@ namespace MsgPack.Serialization
 
 			var table = TypeTable.Create( member.Member );
 
-			var traits = member.Member.GetMemberValueType().GetCollectionTraits( CollectionTraitOptions.None );
+			var traits = member.Member.GetMemberValueType().GetCollectionTraits( CollectionTraitOptions.None, forceCollection: true );
 			switch ( traits.CollectionType )
 			{
 				case CollectionKind.Array:

--- a/src/MsgPack/Serialization/ReflectionSerializers/ReflectionObjectMessagePackSerializer`1.cs
+++ b/src/MsgPack/Serialization/ReflectionSerializers/ReflectionObjectMessagePackSerializer`1.cs
@@ -388,7 +388,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 				throw SerializationExceptions.NewReadOnlyMemberItemsMustNotBeNull( this._contracts[ index ].Name );
 			}
 
-			var traits = destination.GetType().GetCollectionTraits( CollectionTraitOptions.WithAddMethod );
+			var traits = destination.GetType().GetCollectionTraits( CollectionTraitOptions.WithAddMethod, forceCollection: true );
 			if ( traits.AddMethod == null )
 			{
 				throw SerializationExceptions.NewUnpackToIsNotSupported( destination.GetType(), null );
@@ -637,7 +637,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 				throw SerializationExceptions.NewReadOnlyMemberItemsMustNotBeNull( this._contracts[ index ].Name );
 			}
 
-			var traits = destination.GetType().GetCollectionTraits( CollectionTraitOptions.WithAddMethod );
+			var traits = destination.GetType().GetCollectionTraits( CollectionTraitOptions.WithAddMethod, forceCollection: true );
 			if ( traits.AddMethod == null )
 			{
 				throw SerializationExceptions.NewUnpackToIsNotSupported( destination.GetType(), null );

--- a/src/MsgPack/Serialization/SerializationCompatibilityOptions.cs
+++ b/src/MsgPack/Serialization/SerializationCompatibilityOptions.cs
@@ -98,7 +98,7 @@ namespace MsgPack.Serialization
 		///		Gets or sets a value indicating whether serializer generator ignores packability interfaces for collections or not.
 		/// </summary>
 		/// <value>
-		///		<c>true</c> if serializer generator ignores packability interfaces for collections; otherwise, <c>false</c>. The default is <c>true</c>.
+		///		<c>true</c> if serializer generator ignores packability interfaces for collections; otherwise, <c>false</c>. The default is <c>false</c>.
 		/// </value>
 		/// <remarks>
 		///		Historically, MessagePack for CLI ignored packability interfaces (<see cref="IPackable"/>, <see cref="IUnpackable"/>, 
@@ -122,6 +122,43 @@ namespace MsgPack.Serialization
 				this._ignorePackabilityForCollection = value;
 #else
 				Volatile.Write( ref this._ignorePackabilityForCollection, value );
+#endif // NETFX_35 || UNITY || SILVERLIGHT
+			}
+		}
+
+#if NETFX_35 || UNITY || SILVERLIGHT
+		private volatile bool _alwaysAssumeCollections;
+#else
+		private bool _alwaysAssumeCollections;
+#endif // NETFX_35 || UNITY || SILVERLIGHT
+
+		/// <summary>
+		///		Gets or sets a value indicating whether serializer generator should always try to serialize a type implementing IEnumerable as a collection or not.
+		/// </summary>
+		/// <value>
+		///		<c>true</c> if serializer generator should serialize a type implementing IEnumerable as only a collection; otherwise, <c>false</c>. The default is <c>false</c>.
+		/// </value>
+		/// <remarks>
+		///		Historically, MessagePack for CLI always tried to serialize any type that implemented IEnumerable as a collection, throwing an exception
+		///		if an Add method could not be found. However, for types that implement IEnumerable but don't have an Add method the generator will now
+		///		serialize the type as a non-collection type. To restore the old behavior for backwards compatibility, set this option to <c>false</c>.
+		/// </remarks>
+		public bool AlwaysAssumeCollections
+		{
+			get
+			{
+#if NETFX_35 || UNITY || SILVERLIGHT
+				return this._alwaysAssumeCollections;
+#else
+				return Volatile.Read(ref this._alwaysAssumeCollections);
+#endif // NETFX_35 || UNITY || SILVERLIGHT
+			}
+			set
+			{
+#if NETFX_35 || UNITY || SILVERLIGHT
+				this._alwaysAssumeCollections = value;
+#else
+				Volatile.Write(ref this._alwaysAssumeCollections, value);
 #endif // NETFX_35 || UNITY || SILVERLIGHT
 			}
 		}

--- a/src/MsgPack/Serialization/SerializationTarget.cs
+++ b/src/MsgPack/Serialization/SerializationTarget.cs
@@ -386,7 +386,7 @@ namespace MsgPack.Serialization
 				return true;
 			}
 
-			var traits = returnType.GetCollectionTraits( CollectionTraitOptions.WithAddMethod );
+			var traits = returnType.GetCollectionTraits( CollectionTraitOptions.WithAddMethod, forceCollection: true );
 			switch ( traits.CollectionType )
 			{
 				case CollectionKind.Array:

--- a/src/MsgPack/Serialization/SerializerGenerator.cs
+++ b/src/MsgPack/Serialization/SerializerGenerator.cs
@@ -450,7 +450,7 @@ namespace MsgPack.Serialization
 				{
 					realTargetTypes =
 						targetTypes
-						.Where( t => !SerializationTarget.BuiltInSerializerExists( configuration, t, t.GetCollectionTraits( CollectionTraitOptions.None ) ) );
+						.Where( t => !SerializationTarget.BuiltInSerializerExists( configuration, t, t.GetCollectionTraits( CollectionTraitOptions.None, forceCollection: true ) ) );
 				}
 
 				var generationContext = this.CreateGenerationContext( context, configuration );
@@ -476,7 +476,7 @@ namespace MsgPack.Serialization
 
 			private static IEnumerable<Type> ExtractElementTypes( SerializationContext context, ISerializerGeneratorConfiguration configuration, Type type )
 			{
-				if ( !SerializationTarget.BuiltInSerializerExists( configuration, type, type.GetCollectionTraits( CollectionTraitOptions.None ) ) )
+				if ( !SerializationTarget.BuiltInSerializerExists( configuration, type, type.GetCollectionTraits( CollectionTraitOptions.None, forceCollection: true ) ) )
 				{
 					yield return type;
 
@@ -497,7 +497,7 @@ namespace MsgPack.Serialization
 				if ( type.IsArray )
 				{
 					var elementType = type.GetElementType();
-					if ( !SerializationTarget.BuiltInSerializerExists( configuration, elementType, elementType.GetCollectionTraits( CollectionTraitOptions.None ) ) )
+					if ( !SerializationTarget.BuiltInSerializerExists( configuration, elementType, elementType.GetCollectionTraits( CollectionTraitOptions.None, forceCollection: true ) ) )
 					{
 						foreach ( var descendant in ExtractElementTypes( context, configuration, elementType ) )
 						{
@@ -557,7 +557,7 @@ namespace MsgPack.Serialization
 
 			protected override Func<Type, ISerializerCodeGenerator> CreateGeneratorFactory()
 			{
-				return type => new AssemblyBuilderSerializerBuilder( type, type.GetCollectionTraits( CollectionTraitOptions.Full ) );
+				return type => new AssemblyBuilderSerializerBuilder( type, type.GetCollectionTraits( CollectionTraitOptions.Full, forceCollection: true ) );
 			}
 		}
 
@@ -577,7 +577,7 @@ namespace MsgPack.Serialization
 
 			protected override Func<Type, ISerializerCodeGenerator> CreateGeneratorFactory()
 			{
-				return type => new CodeDomSerializerBuilder( type, type.GetCollectionTraits( CollectionTraitOptions.Full ) );
+				return type => new CodeDomSerializerBuilder( type, type.GetCollectionTraits( CollectionTraitOptions.Full, forceCollection: true ) );
 			}
 		}
 	}

--- a/test/MsgPack.UnitTest/MsgPack.UnitTest.csproj
+++ b/test/MsgPack.UnitTest/MsgPack.UnitTest.csproj
@@ -705,6 +705,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>MapReflectionBasedAutoMessagePackSerializerTest.tt</DependentUpon>
     </Compile>
+    <Compile Include="Serialization\NonCollectionIEnumerableTest.cs" />
     <Compile Include="Serialization\PerformanceTest.cs" />
     <Compile Include="Serialization\AppendableReadOnlyCollections.cs" />
     <Compile Include="Serialization\ReflectionBasedNilImplicationTest.cs">

--- a/test/MsgPack.UnitTest/Serialization/CompositeTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/CompositeTest.cs
@@ -79,25 +79,25 @@ namespace MsgPack.Serialization
 		[Test]
 		public void TestArrayFieldBased()
 		{
-			TestCore( EmitterFlavor.FieldBased, SerializationMethod.Array, new AssemblyBuilderSerializerBuilder( typeof( DirectoryItem ), typeof( DirectoryItem ).GetCollectionTraits( CollectionTraitOptions.Full ) ) );
+			TestCore( EmitterFlavor.FieldBased, SerializationMethod.Array, new AssemblyBuilderSerializerBuilder( typeof( DirectoryItem ), typeof( DirectoryItem ).GetCollectionTraits( CollectionTraitOptions.Full, forceCollection: true ) ) );
 		}
 
 		[Test]
 		public void TestMapFieldBased()
 		{
-			TestCore( EmitterFlavor.FieldBased, SerializationMethod.Map, new AssemblyBuilderSerializerBuilder( typeof( DirectoryItem ), typeof( DirectoryItem ).GetCollectionTraits( CollectionTraitOptions.Full ) ) );
+			TestCore( EmitterFlavor.FieldBased, SerializationMethod.Map, new AssemblyBuilderSerializerBuilder( typeof( DirectoryItem ), typeof( DirectoryItem ).GetCollectionTraits( CollectionTraitOptions.Full, forceCollection: true ) ) );
 		}
 
 		[Test]
 		public void TestArrayCodeDomBased()
 		{
-			TestCore( EmitterFlavor.CodeDomBased, SerializationMethod.Array, new CodeDomSerializerBuilder( typeof( DirectoryItem ), typeof( DirectoryItem ).GetCollectionTraits( CollectionTraitOptions.Full ) ) );
+			TestCore( EmitterFlavor.CodeDomBased, SerializationMethod.Array, new CodeDomSerializerBuilder( typeof( DirectoryItem ), typeof( DirectoryItem ).GetCollectionTraits( CollectionTraitOptions.Full, forceCollection: true ) ) );
 		}
 
 		[Test]
 		public void TestMapCodeDomBased()
 		{
-			TestCore( EmitterFlavor.CodeDomBased, SerializationMethod.Map, new CodeDomSerializerBuilder( typeof( DirectoryItem ), typeof( DirectoryItem ).GetCollectionTraits( CollectionTraitOptions.Full ) ) );
+			TestCore( EmitterFlavor.CodeDomBased, SerializationMethod.Map, new CodeDomSerializerBuilder( typeof( DirectoryItem ), typeof( DirectoryItem ).GetCollectionTraits( CollectionTraitOptions.Full, forceCollection: true ) ) );
 		}
 
 		private static void TestCore( EmitterFlavor emittingFlavor, SerializationMethod serializationMethod, ISerializerBuilder generator )

--- a/test/MsgPack.UnitTest/Serialization/NonCollectionIEnumerableTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/NonCollectionIEnumerableTest.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+#if !MSTEST
+using NUnit.Framework;
+#else
+using TestFixtureAttribute = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestClassAttribute;
+using TestAttribute = Microsoft.VisualStudio.TestPlatform.UnitTestFramework.TestMethodAttribute;
+using TimeoutAttribute = NUnit.Framework.TimeoutAttribute;
+using Assert = NUnit.Framework.Assert;
+using Is = NUnit.Framework.Is;
+#endif
+
+namespace MsgPack.Serialization
+{
+	[TestFixture]
+	public sealed class NonCollectionIEnumerableTest
+	{
+		[Test]
+		public void ShouldSerializeATypeImplementingIEnumerableWithoutAnAddMethodAsANormalType()
+		{
+			var context = new SerializationContext();
+			context.SerializationMethod = SerializationMethod.Array;
+			var serializer = context.GetSerializer<NonCollectionType>();
+			using ( var buffer = new MemoryStream() )
+			{
+				var obj = new NonCollectionType { Property = 123 };
+				serializer.Pack(buffer, obj);
+
+				buffer.Position = 0;
+
+				var clone = serializer.Unpack( buffer );
+				Assert.That( clone.Property, Is.EqualTo( 123 ) );
+			}
+		}
+
+		[Serializable]
+		public class NonCollectionType : IEnumerable<int>
+		{
+			public int Property { get; set; }
+
+			public IEnumerator<int> GetEnumerator()
+			{
+				yield break;
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return this.GetEnumerator();
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is designed to fix issue #169 

I've added a compatibility option to disable the new behaviour (`AlwaysAssumeCollections`) and all the unit tests to pass with the refactored code, plus there's an additional one showing the desired behaviour.

Since this is my first pull request let me know if there's anything you need me to do