### PR TITLE
Expose internal serializer option to allow runtime generation to be disabled

### DIFF
--- a/src/MsgPack/Serialization/SerializationContext.cs
+++ b/src/MsgPack/Serialization/SerializationContext.cs
@@ -313,22 +313,6 @@ namespace MsgPack.Serialization
 			get { return this._defaultCollectionTypes; }
 		}
 
-#if !AOT
-
-		/// <summary>
-		///		Gets or sets a value indicating whether runtime generation is disabled or not.
-		/// </summary>
-		/// <value>
-		///		<c>true</c> if runtime generation is disabled; otherwise, <c>false</c>.
-		/// </value>
-		internal bool IsRuntimeGenerationDisabled
-		{
-			get { return this._serializerGeneratorOptions.IsRuntimeGenerationDisabled; }
-			set { this._serializerGeneratorOptions.IsRuntimeGenerationDisabled = value; }
-		}
-
-#endif // !AOT
-
 		private int _defaultDateTimeConversionMethod;
 
 		/// <summary>
@@ -671,7 +655,7 @@ namespace MsgPack.Serialization
 						if ( serializer == null )
 						{
 #if !AOT
-							if ( this._serializerGeneratorOptions.IsRuntimeGenerationDisabled )
+							if ( this._serializerGeneratorOptions.DisableRuntimeCodeGeneration )
 							{
 #endif // AOT
 								// On debugging, or AOT only envs, use reflection based aproach.

--- a/src/MsgPack/Serialization/SerializerOptions.cs
+++ b/src/MsgPack/Serialization/SerializerOptions.cs
@@ -111,12 +111,12 @@ namespace MsgPack.Serialization
 #endif // !FEATURE_CONCURRENT
 
 		/// <summary>
-		///		Gets or sets a value indicating whether runtime generation is disabled or not.
+		///		Gets or sets a value indicating whether runtime generation should be disabled or not.
 		/// </summary>
 		/// <value>
-		///		<c>true</c> if runtime generation is disabled; otherwise, <c>false</c>.
+		///		<c>true</c> if runtime generation is disabled; otherwise, <c>false</c>. Defaults to <c>false</c>.
 		/// </value>
-		internal bool IsRuntimeGenerationDisabled
+		public bool DisableRuntimeCodeGeneration
 		{
 			get
 			{

--- a/test/MsgPack.UnitTest/Serialization/PreGeneratedSerializerActivator.cs
+++ b/test/MsgPack.UnitTest/Serialization/PreGeneratedSerializerActivator.cs
@@ -106,7 +106,7 @@ namespace MsgPack.Serialization
 			}
 
 #if !AOT
-			context.SerializerOptions.IsRuntimeGenerationDisabled = true;
+			context.SerializerOptions.DisableRuntimeCodeGeneration = true;
 #endif // !AOT
 			return context;
 		}


### PR DESCRIPTION
Turns out there was already a bool property that fixes #192 so I renamed it and made it public.

I removed the same property on the SerializerContext as it didn't appear to be referenced anywhere and it would be confusing having two public properties doing the same thing, hope that's OK