### PR TITLE
Fix typo in mpu.exe parameters binding

### DIFF
--- a/src/mpu/Program.cs
+++ b/src/mpu/Program.cs
@@ -139,7 +139,7 @@ namespace mpu
 					},
 					{
 						"singular", "[serializer, optional] Specify avoid recursive serializer generation for target type(s).",
-						_ => configuration.PreferReflectionBasedSerializer = false
+						_ => configuration.IsRecursive = false
 					},
 					{
 						"avoid-reflection-based", "[serializer, optional] Specify avoid built-in reflection based serializer and generates alternative serializers.",


### PR DESCRIPTION
Hi!

Here is simple typo and also i found one more mpu.exe bug:

I get 'Process is terminated due to StackOverflowException.' when trying to prepare serializer for something like:
```
   class Example
   {
       public Example[] Childs; 
   } 
```

I know what it is in this function:
https://github.com/msgpack/msgpack-cli/blob/20ae0c36d292c3f6f51248872e362170fcaf36d4/src/MsgPack/Serialization/SerializerGenerator.cs#L498

But it is so tangled.. i gave up trying to refactor it. I would completely remove it and write again.. But i need more time to understand the logic. You possibly see less radical solution. 