### PR TITLE
New command line argument '--admit-non-public-types'

### DIFF
--- a/src/mpu/Program.cs
+++ b/src/mpu/Program.cs
@@ -83,6 +83,7 @@ namespace mpu
 			var excludingPattern = default( string );
 			var treatWarningsAsErrors = false;
 			var warningLevel = 4;
+			var admitNonPublicTypes = false;
 			var configuration =
 				new SerializerCodeGenerationConfiguration
 				{
@@ -182,6 +183,10 @@ namespace mpu
 						value => excludingPattern = value
 					},
 					{
+						"admit-non-public-types", "[serializer, optional] Specify to enable code generation for non-public types.",
+						_ => admitNonPublicTypes = true
+					},
+					{
 						"treat-warning-as-errors|treatWarningsAsErrors", "[serializer, optional] Specify to generate error for compiler warnings for serialization target types.",
 						_ => treatWarningsAsErrors = true
 					},
@@ -220,6 +225,7 @@ namespace mpu
 						excludingPattern,
 						treatWarningsAsErrors,
 						warningLevel,
+						admitNonPublicTypes,
 						configuration
 					);
 					return 0;
@@ -288,6 +294,7 @@ namespace mpu
 			string excludingPattern,
 			bool treatWarningsAsErrors,
 			int warningLevel,
+			bool admitNonPublicTypes,
 			SerializerCodeGenerationConfiguration configuration
 		)
 		{
@@ -311,7 +318,8 @@ namespace mpu
 							referenceAssemblies ?? new string[ 0 ]
 							),
 						includingPattern,
-						excludingPattern
+						excludingPattern,
+						admitNonPublicTypes
 					);
 			}
 			else
@@ -320,7 +328,8 @@ namespace mpu
 					generator.GenerateSerializers(
 						sourceFilePathes[ 0 ],
 						includingPattern,
-						excludingPattern
+						excludingPattern,
+						admitNonPublicTypes
 					);
 			}
 

--- a/src/mpu/SerializerCodeGenerator.cs
+++ b/src/mpu/SerializerCodeGenerator.cs
@@ -71,14 +71,16 @@ namespace mpu
 		public IEnumerable<string> GenerateSerializers(
 			string sourceAssemblyFile,
 			string includingPattern,
-			string excludingPattern
+			string excludingPattern,
+			bool admitNonPublicTypes
 		)
 		{
 			return
 				this.GenerateSerializers(
 					Assembly.LoadFrom( sourceAssemblyFile ),
 					includingPattern,
-					excludingPattern
+					excludingPattern,
+					admitNonPublicTypes
 				);
 		}
 
@@ -95,7 +97,8 @@ namespace mpu
 		public IEnumerable<string> GenerateSerializers(
 			Assembly sourceAssembly,
 			string includingPattern,
-			string excludingPattern
+			string excludingPattern,
+			bool admitNonPublicTypes
 		)
 		{
 			if ( sourceAssembly == null )
@@ -129,7 +132,7 @@ namespace mpu
 					sourceAssembly.GetTypes()
 						.Where(
 							type =>
-								type.IsPublic
+								(admitNonPublicTypes || type.IsPublic)
 								&& !type.IsAbstract
 								&& !type.IsInterface
 								&& ( includingRegex == null || includingRegex.IsMatch( type.FullName ) )


### PR DESCRIPTION
Currently mpu.exe ignores internal types. 
This feature introduces new argument '--admit-non-public-types', which can be used to make generator to consider non-public types. 