### PR TITLE
Fix appveyor settings.

### DIFF
--- a/appveyor-debug.yml
+++ b/appveyor-debug.yml
@@ -9,7 +9,7 @@ assembly_info:
   assembly_file_version: $(AssemblyBaseVersion).{build}
   assembly_informational_version: $(PackageVersion)
 environment:
-  XamarinMSBuildExtensionsPath: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\
+  XamarinMSBuildExtensionsPath: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild
 install:
 - cmd: >-
     cd .\build

--- a/appveyor-release.yml
+++ b/appveyor-release.yml
@@ -14,7 +14,7 @@ assembly_info:
   assembly_file_version: $(AssemblyBaseVersion).{build}
   assembly_informational_version: $(PackageVersion)
 environment:
-  XamarinMSBuildExtensionsPath: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\
+  XamarinMSBuildExtensionsPath: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild
 install:
 - cmd: >-
     cd .\build


### PR DESCRIPTION
This PR fixes CI settings accidentally commits in master branch directly.

First of all, `dotnet` command has own `MSBuildExtensionsPath` which does not include Xamarin scripts, so we have to specify the path for VS installation (%ProgramFiles(x86)%\Microsoft Visual Studio 2017\Community\MSBuild for AppVeyor). To avoid this, I introduced `XamarinMSBuildExtensionsPath` property to tweak the root path of Xamarin msbuild files for command line build.

This PR fixes wrong path specification which had been added accidentally.