### PR TITLE
Fix UAP build setting. #186

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -707,3 +707,7 @@ Release 0.9.1 2017-8-30
   BUG FIXES
   * Fix ByteArrayPacker throws IndexOutOfBoundException when the buffer remaining bytes is equal to packed scalar size. #252
 
+Release 0.9.2 2017-09-25
+
+  BUG FIXES
+  * Fix UAP build drop does not exists in nupkg. #186

--- a/MsgPack.Windows.sln
+++ b/MsgPack.Windows.sln
@@ -385,7 +385,8 @@ Global
 		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|ARM.ActiveCfg = Release|ARM
 		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|ARM.Build.0 = Release|ARM
-		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|x64.ActiveCfg = Release|x64
 		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|x64.Build.0 = Release|x64
 		{9D65A105-FB03-40DB-9185-8C695B8EE8D6}.Release|x86.ActiveCfg = Release|x86


### PR DESCRIPTION
This PR fixes the build bug that uap package is still missing in nupkg.