### PR TITLE
Issue #278: Support skipping of Member for a Type on serialization without MessagePackIgnoreAttribute

### DIFF
--- a/src/MsgPack/Serialization/SerializationContext.MemberIgnore.cs
+++ b/src/MsgPack/Serialization/SerializationContext.MemberIgnore.cs
@@ -1,0 +1,44 @@
+#region -- License Terms --
+// 
+// MessagePack for CLI
+// 
+// Copyright (C) 2015 FUJIWARA, Yusuke
+// 
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+// 
+//        http://www.apache.org/licenses/LICENSE-2.0
+// 
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+// 
+#endregion -- License Terms --
+
+using System;
+using System.Collections.Generic;
+
+namespace MsgPack.Serialization
+{
+	partial class SerializationContext
+	{
+		/// <summary>
+		/// The type member ignore list
+		/// </summary>
+		private readonly IDictionary<Type, IEnumerable<string>> _typesMemberIgnoreList = new Dictionary<Type, IEnumerable<string>>();
+
+		/// <summary>
+		///		Gets the mapping of type specific members which required to be ignored in serialization.
+		/// </summary>
+		/// <value>
+		///		The mapping of type specific members which required to be ignored in serialization
+		/// </value>
+		public IDictionary<Type, IEnumerable<string>> TypesMemberIgnoreList
+		{
+			get { return this._typesMemberIgnoreList; }
+		}
+	}
+}

--- a/src/MsgPack/Serialization/SerializationTarget.cs
+++ b/src/MsgPack/Serialization/SerializationTarget.cs
@@ -117,18 +117,18 @@ namespace MsgPack.Serialization
 			switch ( membersArray.Length )
 			{
 				case 0:
-				{
-					return null;
-				}
+					{
+						return null;
+					}
 				case 1:
-				{
-					return membersArray[ 0 ].MemberName;
-				}
+					{
+						return membersArray[ 0 ].MemberName;
+					}
 				default:
-				{
-					ThrowAmbigiousMatchException( parameterInfo, membersArray );
-					return null;
-				}
+					{
+						ThrowAmbigiousMatchException( parameterInfo, membersArray );
+						return null;
+					}
 			}
 		}
 
@@ -169,7 +169,16 @@ namespace MsgPack.Serialization
 		{
 			VerifyCanSerializeTargetType( context, targetType );
 
-			var getters = GetTargetMembers( targetType ).OrderBy( entry => entry.Contract.Id ).ToArray();
+			IEnumerable<string> memberIgnoreList;
+			if ( !context.TypesMemberIgnoreList.TryGetValue( targetType, out memberIgnoreList ) )
+			{
+				memberIgnoreList = Enumerable.Empty<string>();
+			}
+
+			var getters = GetTargetMembers( targetType )
+						  .Where( entry => !memberIgnoreList.Contains( entry.MemberName, StringComparer.Ordinal ) )
+						  .OrderBy( entry => entry.Contract.Id )
+						  .ToArray();
 
 			if ( getters.Length == 0
 				&& !typeof( IPackable ).IsAssignableFrom( targetType )
@@ -294,26 +303,26 @@ namespace MsgPack.Serialization
 			switch ( kind )
 			{
 				case ConstructorKind.Marked:
-				{
-					Trace( "SerializationTarget::DetermineCanDeserialize({0}, {1}) -> true: Marked", targetType, kind );
-					return true;
-				}
+					{
+						Trace( "SerializationTarget::DetermineCanDeserialize({0}, {1}) -> true: Marked", targetType, kind );
+						return true;
+					}
 				case ConstructorKind.Parameterful:
-				{
-					var result = HasAnyCorrespondingMembers( correspondingMemberNames );
-					Trace( "SerializationTarget::DetermineCanDeserialize({0}, {1}) -> {2}: HasAnyCorrespondingMembers", targetType, kind, result );
-					return result;
-				}
+					{
+						var result = HasAnyCorrespondingMembers( correspondingMemberNames );
+						Trace( "SerializationTarget::DetermineCanDeserialize({0}, {1}) -> {2}: HasAnyCorrespondingMembers", targetType, kind, result );
+						return result;
+					}
 				case ConstructorKind.Default:
-				{
-					Trace( "SerializationTarget::DetermineCanDeserialize({0}, {1}) -> {2}: Default", targetType, kind, allowDefault );
-					return allowDefault;
-				}
+					{
+						Trace( "SerializationTarget::DetermineCanDeserialize({0}, {1}) -> {2}: Default", targetType, kind, allowDefault );
+						return allowDefault;
+					}
 				default:
-				{
-					Contract.Assert( kind == ConstructorKind.None || kind == ConstructorKind.Ambiguous, "kind == ConstructorKind.None || kind == ConstructorKind.Ambiguous : " + kind );
-					return false;
-				}
+					{
+						Contract.Assert( kind == ConstructorKind.None || kind == ConstructorKind.Ambiguous, "kind == ConstructorKind.None || kind == ConstructorKind.Ambiguous : " + kind );
+						return false;
+					}
 			}
 		}
 
@@ -489,25 +498,25 @@ namespace MsgPack.Serialization
 			switch ( markedConstructors.Count )
 			{
 				case 0:
-				{
-					break;
-				}
+					{
+						break;
+					}
 				case 1:
-				{
-					// OK use it for deserialization.
-					constructorKind = ConstructorKind.Marked;
-					return markedConstructors[ 0 ];
-				}
+					{
+						// OK use it for deserialization.
+						constructorKind = ConstructorKind.Marked;
+						return markedConstructors[ 0 ];
+					}
 				default:
-				{
-					throw new SerializationException(
-						String.Format(
-							CultureInfo.CurrentCulture,
-							"There are multiple constructors marked with MessagePackDeserializationConstrutorAttribute in type '{0}'.",
-							targetType
-						)
-					);
-				}
+					{
+						throw new SerializationException(
+							String.Format(
+								CultureInfo.CurrentCulture,
+								"There are multiple constructors marked with MessagePackDeserializationConstrutorAttribute in type '{0}'.",
+								targetType
+							)
+						);
+					}
 			}
 
 			// A constructor which has most parameters will be used.
@@ -519,43 +528,43 @@ namespace MsgPack.Serialization
 			switch ( mostRichConstructors.Length )
 			{
 				case 1:
-				{
-					if ( mostRichConstructors[ 0 ].GetParameters().Length == 0 )
+					{
+						if ( mostRichConstructors[ 0 ].GetParameters().Length == 0 )
+						{
+							if ( context.CompatibilityOptions.AllowAsymmetricSerializer )
+							{
+								constructorKind = ConstructorKind.Default;
+								return mostRichConstructors[ 0 ];
+							}
+							else
+							{
+								throw NewTypeCannotBeSerializedException( targetType );
+							}
+						}
+
+						// OK try use it but it may not handle deserialization correctly.
+						constructorKind = ConstructorKind.Parameterful;
+						return mostRichConstructors[ 0 ];
+					}
+				default:
 					{
 						if ( context.CompatibilityOptions.AllowAsymmetricSerializer )
 						{
-							constructorKind = ConstructorKind.Default;
-							return mostRichConstructors[ 0 ];
+							constructorKind = ConstructorKind.Ambiguous;
+							return null;
 						}
 						else
 						{
-							throw NewTypeCannotBeSerializedException( targetType );
+							throw new SerializationException(
+								String.Format(
+									CultureInfo.CurrentCulture,
+									"Cannot serialize type '{0}' because it does not have any serializable fields nor properties, and serializer generator failed to determine constructor to deserialize among({1}).",
+									targetType,
+									String.Join( ", ", mostRichConstructors.Select( ctor => ctor.ToString() ).ToArray() )
+								)
+							);
 						}
 					}
-
-					// OK try use it but it may not handle deserialization correctly.
-					constructorKind = ConstructorKind.Parameterful;
-					return mostRichConstructors[ 0 ];
-				}
-				default:
-				{
-					if ( context.CompatibilityOptions.AllowAsymmetricSerializer )
-					{
-						constructorKind = ConstructorKind.Ambiguous;
-						return null;
-					}
-					else
-					{
-						throw new SerializationException(
-							String.Format(
-								CultureInfo.CurrentCulture,
-								"Cannot serialize type '{0}' because it does not have any serializable fields nor properties, and serializer generator failed to determine constructor to deserialize among({1}).",
-								targetType,
-								String.Join( ", ", mostRichConstructors.Select( ctor => ctor.ToString() ).ToArray() )
-							)
-						);
-					}
-				}
 			}
 		}
 
@@ -635,13 +644,13 @@ namespace MsgPack.Serialization
 			{
 				case CollectionKind.Array:
 				case CollectionKind.Map:
-				{
-					return traits.AddMethod != null;
-				}
+					{
+						return traits.AddMethod != null;
+					}
 				default:
-				{
-					return false;
-				}
+					{
+						return false;
+					}
 			}
 		}
 

--- a/test/MsgPack.UnitTest/MessagePackMemberSkipTest.cs
+++ b/test/MsgPack.UnitTest/MessagePackMemberSkipTest.cs
@@ -1,0 +1,105 @@
+#region -- License Terms --
+//
+// MessagePack for CLI
+//
+// Copyright (C) 2010-2012 FUJIWARA, Yusuke
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+#endregion -- License Terms --
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using MsgPack.Serialization;
+
+using NUnit.Framework; // For running checking
+
+namespace MsgPack
+{
+	[TestFixture]
+	public class MessagePackMemberSkipTest
+	{
+		[Test]
+		public void SerializeThenDeserialize()
+		{
+			// They are object for just description. 
+			var targetObject = new PhotoEntry
+			{
+				Id = 123,
+				Title = "My photo",
+				Date = DateTime.Now,
+				Image = new byte[] { 1, 2, 3, 4 },
+				Comment = "This is test object to be serialize/deserialize using MsgPack."
+			};
+
+			targetObject.Tags.Add( new PhotoTag { Name = "Sample", Id = 123 } );
+			targetObject.Tags.Add( new PhotoTag { Name = "Excellent", Id = 456 } );
+			var stream = new MemoryStream();
+
+			// 1. Create serializer instance.
+			SerializationContext context = new SerializationContext();
+			context.DefaultDateTimeConversionMethod = DateTimeConversionMethod.Native;
+			context.TypesMemberIgnoreList.Add( typeof( PhotoEntry ), new[] { nameof( PhotoEntry.Image ) } );
+			context.TypesMemberIgnoreList.Add( typeof( PhotoTag ), new[] { nameof( PhotoTag.Name ) } );
+			var serializer = MessagePackSerializer.Get<PhotoEntry>( context );
+
+			// 2. Serialize object to the specified stream.
+			serializer.Pack( stream, targetObject );
+
+			// Set position to head of the stream to demonstrate deserialization.
+			stream.Position = 0;
+
+			// 3. Deserialize object from the specified stream.
+			var deserializedObject = serializer.Unpack( stream );
+
+			Assert.AreEqual( targetObject.Comment, deserializedObject.Comment );
+			Assert.AreEqual( targetObject.Id, deserializedObject.Id );
+			Assert.AreEqual( targetObject.Date, deserializedObject.Date );
+			Assert.AreEqual( targetObject.Title, deserializedObject.Title );
+			Assert.Null( deserializedObject.Image );
+			Assert.AreEqual( targetObject.Tags.Count, deserializedObject.Tags.Count );
+			for ( int i = 0; i < deserializedObject.Tags.Count; i++ )
+			{
+				Assert.AreEqual( targetObject.Tags[ i ].Id, deserializedObject.Tags[ i ].Id );
+				Assert.Null( deserializedObject.Tags[ i ].Name );
+			}
+		}
+	}
+
+	/// <summary>
+	///	Simple class that will be used for serialization/deserialization.
+	/// </summary>
+	/// <remarks>
+	/// If you want to interop with other platform using SerializationMethod.Array (default), you should use [MessagePackMember]. See Sample06 for details.
+	/// </remarks>
+	public class PhotoEntry
+	{
+		public long Id { get; set; }
+		public string Title { get; set; }
+		public DateTime Date { get; set; }
+		public string Comment { get; set; }
+		public byte[] Image { get; set; }
+		private readonly List<PhotoTag> _tags = new List<PhotoTag>();
+		// Note that non-null read-only collection members are OK (of course, collections themselves must not be readonly.)
+		public IList<PhotoTag> Tags { get { return this._tags; } }
+	}
+
+	public class PhotoTag
+	{
+		public long Id { get; set; }
+
+		public string Name { get; set; }
+	}
+}


### PR DESCRIPTION
These implementation, allows to serialize objects without design time define object's member needs to skip serialization. These is very helpful in case where applications which reuse existing code and APIs needs to transfer data between tiers, while API call uses shared objects, which have all property populated, while caller on that APIs not interested or required all values, but because of shared logic and objects, it serialized everything. and its not possible to mark object on designtime as based on API, object members populated values required while for other it may not.