### PR TITLE
rename DictionarySerlaizationOptions to DictionarySerializationOptions

### DIFF
--- a/samples/Samples/Sample03_SerializationContextAndOptions.cs
+++ b/samples/Samples/Sample03_SerializationContextAndOptions.cs
@@ -57,9 +57,9 @@ namespace Samples
 
 			// 2-2-1. You can customize map key handling when you use SerializationMethod.Map to improve interoperability.
 			//        You can use preconfigured transformation in DictionaryKeyTransformers class.
-			context.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
+			context.DictionarySerializationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
 			// 2-2-2. You can omit entry when map value is null.
-			context.DictionarySerlaizationOptions.OmitNullEntry = true;
+			context.DictionarySerializationOptions.OmitNullEntry = true;
 
 			// 2-3. EnumSerializationMethod: it changes enum serialization as their name or underlying value.
 			//          ByName(default): More version torrelant and interoperable, and backward compatible prior to 0.5 of MsgPack for CLI.

--- a/src/MsgPack/Serialization/AbstractSerializers/SerializerBuilder`2.Object.cs
+++ b/src/MsgPack/Serialization/AbstractSerializers/SerializerBuilder`2.Object.cs
@@ -572,7 +572,7 @@ namespace MsgPack.Serialization.AbstractSerializers
 							actionCollection.ContextType,
 							"Item",
 							// Set key as transformed.
-							this.MakeStringLiteral( context, context.SerializationContext.DictionarySerlaizationOptions.SafeKeyTransformer( knownActions[ i ].Key ) ),
+							this.MakeStringLiteral( context, context.SerializationContext.DictionarySerializationOptions.SafeKeyTransformer( knownActions[ i ].Key ) ),
 							packItemBody
 						);
 				}
@@ -633,7 +633,7 @@ namespace MsgPack.Serialization.AbstractSerializers
 						actionCollection.ContextType,
 						"Item",
 						// Set key as transformed.
-						this.MakeStringLiteral( context, context.SerializationContext.DictionarySerlaizationOptions.SafeKeyTransformer( knownActions[ i ].Key ) ),
+						this.MakeStringLiteral( context, context.SerializationContext.DictionarySerializationOptions.SafeKeyTransformer( knownActions[ i ].Key ) ),
 						this.EmitNewPrivateMethodDelegateExpression(
 							context,
 							knownActions[ i ].Value
@@ -1351,7 +1351,7 @@ namespace MsgPack.Serialization.AbstractSerializers
 							actionCollection.ContextType,
 							"Item",
 							// Set key as transformed.
-							this.MakeStringLiteral( context, context.SerializationContext.DictionarySerlaizationOptions.SafeKeyTransformer( knownActions[ i ].Key ) ),
+							this.MakeStringLiteral( context, context.SerializationContext.DictionarySerializationOptions.SafeKeyTransformer( knownActions[ i ].Key ) ),
 							unpackItemBody
 						);
 				}

--- a/src/MsgPack/Serialization/DictionaryKeyTransformers.cs
+++ b/src/MsgPack/Serialization/DictionaryKeyTransformers.cs
@@ -23,7 +23,7 @@ using System;
 namespace MsgPack.Serialization
 {
 	/// <summary>
-	///		Defines built-in, out-of-box handlers for <see cref="DictionarySerlaizationOptions.KeyTransformer"/>.
+	///		Defines built-in, out-of-box handlers for <see cref="DictionarySerializationOptions.KeyTransformer"/>.
 	/// </summary>
 	public static class DictionaryKeyTransformers
 	{

--- a/src/MsgPack/Serialization/DictionarySerializationOptions.cs
+++ b/src/MsgPack/Serialization/DictionarySerializationOptions.cs
@@ -1,4 +1,4 @@
-﻿#region -- License Terms --
+#region -- License Terms --
 //
 // MessagePack for CLI
 //
@@ -35,7 +35,7 @@ namespace MsgPack.Serialization
 	///		and <see cref="System.Collections.Generic.IDictionary{TKey, TValue}"/>.
 	///		The option only affect dictionary (map) based serialization which can be enabled via <see cref="SerializationContext.SerializationMethod"/>.
 	/// </remarks>
-	public sealed class DictionarySerlaizationOptions
+	public sealed class DictionarySerializationOptions
 	{
 #if !FEATURE_CONCURRENT
 		private volatile bool _omitNullEntry;
@@ -121,8 +121,8 @@ namespace MsgPack.Serialization
 		} 
 
 		/// <summary>
-		///		Initializes a new instance of the <see cref="DictionarySerlaizationOptions"/> class.
+		///		Initializes a new instance of the <see cref="DictionarySerializationOptions"/> class.
 		/// </summary>
-		public DictionarySerlaizationOptions() { }
+		public DictionarySerializationOptions() { }
 	}
 }

--- a/src/MsgPack/Serialization/PackHelpers.cs
+++ b/src/MsgPack/Serialization/PackHelpers.cs
@@ -339,7 +339,7 @@ namespace MsgPack.Serialization
 #endif // ASSERT
 
 			if ( parameter.NullCheckers != null 
-				&& parameter.SerializationContext != null && parameter.SerializationContext.DictionarySerlaizationOptions.OmitNullEntry )
+				&& parameter.SerializationContext != null && parameter.SerializationContext.DictionarySerializationOptions.OmitNullEntry )
 			{
 #if ASSERT
 				Contract.Assert( !SerializerDebugging.UseLegacyNullMapEntryHandling );
@@ -487,7 +487,7 @@ namespace MsgPack.Serialization
 #endif // ASSERT
 
 			if ( nullCheckers != null
-				&& serializationContext != null && serializationContext.DictionarySerlaizationOptions.OmitNullEntry )
+				&& serializationContext != null && serializationContext.DictionarySerializationOptions.OmitNullEntry )
 			{
 #if ASSERT
 				Contract.Assert( !SerializerDebugging.UseLegacyNullMapEntryHandling );

--- a/src/MsgPack/Serialization/ReflectionSerializers/ReflectionObjectMessagePackSerializer`1.cs
+++ b/src/MsgPack/Serialization/ReflectionSerializers/ReflectionObjectMessagePackSerializer`1.cs
@@ -66,7 +66,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 					.Select( ( contract, index ) => new KeyValuePair<string, int>( contract.Name, index ) )
 					.Where( kv => kv.Key != null )
 					// Set key as transformed.
-					.ToDictionary( kv => context.DictionarySerlaizationOptions.SafeKeyTransformer( kv.Key ), kv => kv.Value );
+					.ToDictionary( kv => context.DictionarySerializationOptions.SafeKeyTransformer( kv.Key ), kv => kv.Value );
 			this._constructorParameters =
 				( !typeof( IUnpackable ).IsAssignableFrom( typeof( T ) ) && target.IsConstructorDeserialization )
 					? target.DeserializationConstructor.GetParameters()
@@ -112,7 +112,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 			}
 			else
 			{
-				if ( this.OwnerContext.DictionarySerlaizationOptions.OmitNullEntry
+				if ( this.OwnerContext.DictionarySerializationOptions.OmitNullEntry
 #if DEBUG
 					&& !SerializerDebugging.UseLegacyNullMapEntryHandling
 #endif // DEBUG
@@ -138,7 +138,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 						}
 
 						// Set key as transformed.
-						packer.PackString( this.OwnerContext.DictionarySerlaizationOptions.SafeKeyTransformer( this._contracts[ i ].Name ) );
+						packer.PackString( this.OwnerContext.DictionarySerializationOptions.SafeKeyTransformer( this._contracts[ i ].Name ) );
 						this.PackMemberValue( packer, objectTree, i );
 					}
 				}
@@ -148,7 +148,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 					for ( int i = 0; i < this._serializers.Length; i++ )
 					{
 						// Set key as transformed.
-						packer.PackString( this.OwnerContext.DictionarySerlaizationOptions.SafeKeyTransformer( this._contracts[ i ].Name ) );
+						packer.PackString( this.OwnerContext.DictionarySerializationOptions.SafeKeyTransformer( this._contracts[ i ].Name ) );
 						this.PackMemberValue( packer, objectTree, i );
 					}
 				}
@@ -214,7 +214,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 			}
 			else
 			{
-				if ( this.OwnerContext.DictionarySerlaizationOptions.OmitNullEntry
+				if ( this.OwnerContext.DictionarySerializationOptions.OmitNullEntry
 #if DEBUG
 					&& !SerializerDebugging.UseLegacyNullMapEntryHandling
 #endif // DEBUG
@@ -240,7 +240,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 						}
 
 						// Set key as transformed.
-						await packer.PackStringAsync( this.OwnerContext.DictionarySerlaizationOptions.SafeKeyTransformer( this._contracts[ i ].Name ), cancellationToken ).ConfigureAwait( false );
+						await packer.PackStringAsync( this.OwnerContext.DictionarySerializationOptions.SafeKeyTransformer( this._contracts[ i ].Name ), cancellationToken ).ConfigureAwait( false );
 						await this.PackMemberValueAsync( packer, objectTree, i, cancellationToken ).ConfigureAwait( false );
 					}
 				}
@@ -250,7 +250,7 @@ namespace MsgPack.Serialization.ReflectionSerializers
 					for ( int i = 0; i < this._serializers.Length; i++ )
 					{
 						// Set key as transformed.
-						await packer.PackStringAsync( this.OwnerContext.DictionarySerlaizationOptions.SafeKeyTransformer( this._contracts[ i ].Name ), cancellationToken ).ConfigureAwait( false );
+						await packer.PackStringAsync( this.OwnerContext.DictionarySerializationOptions.SafeKeyTransformer( this._contracts[ i ].Name ), cancellationToken ).ConfigureAwait( false );
 						await this.PackMemberValueAsync( packer, objectTree, i, cancellationToken ).ConfigureAwait( false );
 					}
 				}

--- a/src/MsgPack/Serialization/SerializationContext.cs
+++ b/src/MsgPack/Serialization/SerializationContext.cs
@@ -176,20 +176,20 @@ namespace MsgPack.Serialization
 			}
 		}
 
-		private readonly DictionarySerlaizationOptions _dictionarySerializationOptions;
+		private readonly DictionarySerializationOptions _dictionarySerializationOptions;
 
 		/// <summary>
 		///		Gets the dictionary(map) based serialization options.
 		/// </summary>
 		/// <value>
-		///		The <see cref="DictionarySerlaizationOptions"/> which stores dictionary(map) based serialization options. This value will not be <c>null</c>.
+		///		The <see cref="DictionarySerializationOptions"/> which stores dictionary(map) based serialization options. This value will not be <c>null</c>.
 		/// </value>
-		public DictionarySerlaizationOptions DictionarySerlaizationOptions
+		public DictionarySerializationOptions DictionarySerializationOptions
 		{
 			get
 			{
 #if DEBUG
-				Contract.Ensures( Contract.Result<DictionarySerlaizationOptions>() != null );
+				Contract.Ensures( Contract.Result<DictionarySerializationOptions>() != null );
 #endif // DEBUG
 
 				return this._dictionarySerializationOptions;
@@ -541,7 +541,7 @@ namespace MsgPack.Serialization
 			this._generationLock = new object();
 			this._defaultCollectionTypes = new DefaultConcreteTypeRepository();
 			this._serializerGeneratorOptions = new SerializerOptions();
-			this._dictionarySerializationOptions = new DictionarySerlaizationOptions();
+			this._dictionarySerializationOptions = new DictionarySerializationOptions();
 			this._enumSerializationOptions = new EnumSerializationOptions();
 		}
 

--- a/test/MsgPack.UnitTest.CodeDom/Serialization/MapCodeDomBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest.CodeDom/Serialization/MapCodeDomBasedAutoMessagePackSerializerTest.cs
@@ -9076,9 +9076,9 @@ namespace MsgPack.Serialization
 		public void TestOmitNullEntryInDictionary()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.OmitNullEntry, Is.False, "default value" );
+			Assert.That( context.DictionarySerializationOptions.OmitNullEntry, Is.False, "default value" );
 			TestOmitNullEntryInDictionaryCore( context, true, false );
-			context.DictionarySerlaizationOptions.OmitNullEntry = true;
+			context.DictionarySerializationOptions.OmitNullEntry = true;
 			TestOmitNullEntryInDictionaryCore( context, false, false );
 		}
 
@@ -9088,9 +9088,9 @@ namespace MsgPack.Serialization
 		public void TestOmitNullEntryInDictionary_Async()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.OmitNullEntry, Is.False, "default value" );
+			Assert.That( context.DictionarySerializationOptions.OmitNullEntry, Is.False, "default value" );
 			TestOmitNullEntryInDictionaryCore( context, true, true );
-			context.DictionarySerlaizationOptions.OmitNullEntry = true;
+			context.DictionarySerializationOptions.OmitNullEntry = true;
 			TestOmitNullEntryInDictionaryCore( context, false, true );
 		}
 
@@ -9103,7 +9103,7 @@ namespace MsgPack.Serialization
 			try
 			{
 				var context = GetSerializationContext();
-				context.DictionarySerlaizationOptions.OmitNullEntry = true;
+				context.DictionarySerializationOptions.OmitNullEntry = true;
 				TestOmitNullEntryInDictionaryCore( context, true, false );
 			}
 			finally
@@ -9121,7 +9121,7 @@ namespace MsgPack.Serialization
 			try
 			{
 				var context = GetSerializationContext();
-				context.DictionarySerlaizationOptions.OmitNullEntry = true;
+				context.DictionarySerializationOptions.OmitNullEntry = true;
 				TestOmitNullEntryInDictionaryCore( context, true, true );
 			}
 			finally
@@ -9195,7 +9195,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Default_AsIs()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.KeyTransformer, Is.Null, "default value" );
+			Assert.That( context.DictionarySerializationOptions.KeyTransformer, Is.Null, "default value" );
 			TestDictionaryKeyCore( context, "FirstProperty", "SecondProperty", "ThirdProperty", "FourthProperty", asIs: true, isAsync: false );
 		}
 
@@ -9205,7 +9205,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Default_AsIs_Async()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.KeyTransformer, Is.Null, "default value" );
+			Assert.That( context.DictionarySerializationOptions.KeyTransformer, Is.Null, "default value" );
 			TestDictionaryKeyCore( context, "FirstProperty", "SecondProperty", "ThirdProperty", "FourthProperty", asIs: true, isAsync: true );
 		}
 
@@ -9215,7 +9215,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_LowerCamel()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
+			context.DictionarySerializationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
 			TestDictionaryKeyCore( context, "firstProperty", "secondProperty", "thirdProperty", "fourthProperty", asIs: false, isAsync: false );
 		}
 
@@ -9225,7 +9225,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_LowerCamel_Async()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
+			context.DictionarySerializationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
 			TestDictionaryKeyCore( context, "firstProperty", "secondProperty", "thirdProperty", "fourthProperty", asIs: false, isAsync: true );
 		}
 
@@ -9235,7 +9235,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Custom()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = 
+			context.DictionarySerializationOptions.KeyTransformer = 
 				key => Regex.Replace( key, "[A-Z]", match => match.Index == 0 ? match.Value.ToLower() : "-" + match.Value.ToLower() );
 			TestDictionaryKeyCore( context, "first-property", "second-property", "third-property", "fourth-property", asIs: false, isAsync: false );
 		}
@@ -9246,7 +9246,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Custom_Async()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = 
+			context.DictionarySerializationOptions.KeyTransformer = 
 				key => Regex.Replace( key, "[A-Z]", match => match.Index == 0 ? match.Value.ToLower() : "-" + match.Value.ToLower() );
 			TestDictionaryKeyCore( context, "first-property", "second-property", "third-property", "fourth-property", asIs: false, isAsync: true );
 		}

--- a/test/MsgPack.UnitTest/Serialization/MapFieldBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/MapFieldBasedAutoMessagePackSerializerTest.cs
@@ -9076,9 +9076,9 @@ namespace MsgPack.Serialization
 		public void TestOmitNullEntryInDictionary()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.OmitNullEntry, Is.False, "default value" );
+			Assert.That( context.DictionarySerializationOptions.OmitNullEntry, Is.False, "default value" );
 			TestOmitNullEntryInDictionaryCore( context, true, false );
-			context.DictionarySerlaizationOptions.OmitNullEntry = true;
+			context.DictionarySerializationOptions.OmitNullEntry = true;
 			TestOmitNullEntryInDictionaryCore( context, false, false );
 		}
 
@@ -9088,9 +9088,9 @@ namespace MsgPack.Serialization
 		public void TestOmitNullEntryInDictionary_Async()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.OmitNullEntry, Is.False, "default value" );
+			Assert.That( context.DictionarySerializationOptions.OmitNullEntry, Is.False, "default value" );
 			TestOmitNullEntryInDictionaryCore( context, true, true );
-			context.DictionarySerlaizationOptions.OmitNullEntry = true;
+			context.DictionarySerializationOptions.OmitNullEntry = true;
 			TestOmitNullEntryInDictionaryCore( context, false, true );
 		}
 
@@ -9103,7 +9103,7 @@ namespace MsgPack.Serialization
 			try
 			{
 				var context = GetSerializationContext();
-				context.DictionarySerlaizationOptions.OmitNullEntry = true;
+				context.DictionarySerializationOptions.OmitNullEntry = true;
 				TestOmitNullEntryInDictionaryCore( context, true, false );
 			}
 			finally
@@ -9121,7 +9121,7 @@ namespace MsgPack.Serialization
 			try
 			{
 				var context = GetSerializationContext();
-				context.DictionarySerlaizationOptions.OmitNullEntry = true;
+				context.DictionarySerializationOptions.OmitNullEntry = true;
 				TestOmitNullEntryInDictionaryCore( context, true, true );
 			}
 			finally
@@ -9195,7 +9195,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Default_AsIs()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.KeyTransformer, Is.Null, "default value" );
+			Assert.That( context.DictionarySerializationOptions.KeyTransformer, Is.Null, "default value" );
 			TestDictionaryKeyCore( context, "FirstProperty", "SecondProperty", "ThirdProperty", "FourthProperty", asIs: true, isAsync: false );
 		}
 
@@ -9205,7 +9205,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Default_AsIs_Async()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.KeyTransformer, Is.Null, "default value" );
+			Assert.That( context.DictionarySerializationOptions.KeyTransformer, Is.Null, "default value" );
 			TestDictionaryKeyCore( context, "FirstProperty", "SecondProperty", "ThirdProperty", "FourthProperty", asIs: true, isAsync: true );
 		}
 
@@ -9215,7 +9215,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_LowerCamel()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
+			context.DictionarySerializationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
 			TestDictionaryKeyCore( context, "firstProperty", "secondProperty", "thirdProperty", "fourthProperty", asIs: false, isAsync: false );
 		}
 
@@ -9225,7 +9225,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_LowerCamel_Async()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
+			context.DictionarySerializationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
 			TestDictionaryKeyCore( context, "firstProperty", "secondProperty", "thirdProperty", "fourthProperty", asIs: false, isAsync: true );
 		}
 
@@ -9235,7 +9235,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Custom()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = 
+			context.DictionarySerializationOptions.KeyTransformer = 
 				key => Regex.Replace( key, "[A-Z]", match => match.Index == 0 ? match.Value.ToLower() : "-" + match.Value.ToLower() );
 			TestDictionaryKeyCore( context, "first-property", "second-property", "third-property", "fourth-property", asIs: false, isAsync: false );
 		}
@@ -9246,7 +9246,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Custom_Async()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = 
+			context.DictionarySerializationOptions.KeyTransformer = 
 				key => Regex.Replace( key, "[A-Z]", match => match.Index == 0 ? match.Value.ToLower() : "-" + match.Value.ToLower() );
 			TestDictionaryKeyCore( context, "first-property", "second-property", "third-property", "fourth-property", asIs: false, isAsync: true );
 		}

--- a/test/MsgPack.UnitTest/Serialization/MapReflectionBasedAutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/MapReflectionBasedAutoMessagePackSerializerTest.cs
@@ -8977,9 +8977,9 @@ namespace MsgPack.Serialization
 		public void TestOmitNullEntryInDictionary()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.OmitNullEntry, Is.False, "default value" );
+			Assert.That( context.DictionarySerializationOptions.OmitNullEntry, Is.False, "default value" );
 			TestOmitNullEntryInDictionaryCore( context, true, false );
-			context.DictionarySerlaizationOptions.OmitNullEntry = true;
+			context.DictionarySerializationOptions.OmitNullEntry = true;
 			TestOmitNullEntryInDictionaryCore( context, false, false );
 		}
 
@@ -8989,9 +8989,9 @@ namespace MsgPack.Serialization
 		public void TestOmitNullEntryInDictionary_Async()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.OmitNullEntry, Is.False, "default value" );
+			Assert.That( context.DictionarySerializationOptions.OmitNullEntry, Is.False, "default value" );
 			TestOmitNullEntryInDictionaryCore( context, true, true );
-			context.DictionarySerlaizationOptions.OmitNullEntry = true;
+			context.DictionarySerializationOptions.OmitNullEntry = true;
 			TestOmitNullEntryInDictionaryCore( context, false, true );
 		}
 
@@ -9004,7 +9004,7 @@ namespace MsgPack.Serialization
 			try
 			{
 				var context = GetSerializationContext();
-				context.DictionarySerlaizationOptions.OmitNullEntry = true;
+				context.DictionarySerializationOptions.OmitNullEntry = true;
 				TestOmitNullEntryInDictionaryCore( context, true, false );
 			}
 			finally
@@ -9022,7 +9022,7 @@ namespace MsgPack.Serialization
 			try
 			{
 				var context = GetSerializationContext();
-				context.DictionarySerlaizationOptions.OmitNullEntry = true;
+				context.DictionarySerializationOptions.OmitNullEntry = true;
 				TestOmitNullEntryInDictionaryCore( context, true, true );
 			}
 			finally
@@ -9096,7 +9096,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Default_AsIs()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.KeyTransformer, Is.Null, "default value" );
+			Assert.That( context.DictionarySerializationOptions.KeyTransformer, Is.Null, "default value" );
 			TestDictionaryKeyCore( context, "FirstProperty", "SecondProperty", "ThirdProperty", "FourthProperty", asIs: true, isAsync: false );
 		}
 
@@ -9106,7 +9106,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Default_AsIs_Async()
 		{
 			var context = GetSerializationContext();
-			Assert.That( context.DictionarySerlaizationOptions.KeyTransformer, Is.Null, "default value" );
+			Assert.That( context.DictionarySerializationOptions.KeyTransformer, Is.Null, "default value" );
 			TestDictionaryKeyCore( context, "FirstProperty", "SecondProperty", "ThirdProperty", "FourthProperty", asIs: true, isAsync: true );
 		}
 
@@ -9116,7 +9116,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_LowerCamel()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
+			context.DictionarySerializationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
 			TestDictionaryKeyCore( context, "firstProperty", "secondProperty", "thirdProperty", "fourthProperty", asIs: false, isAsync: false );
 		}
 
@@ -9126,7 +9126,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_LowerCamel_Async()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
+			context.DictionarySerializationOptions.KeyTransformer = DictionaryKeyTransformers.LowerCamel;
 			TestDictionaryKeyCore( context, "firstProperty", "secondProperty", "thirdProperty", "fourthProperty", asIs: false, isAsync: true );
 		}
 
@@ -9136,7 +9136,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Custom()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = 
+			context.DictionarySerializationOptions.KeyTransformer = 
 				key => Regex.Replace( key, "[A-Z]", match => match.Index == 0 ? match.Value.ToLower() : "-" + match.Value.ToLower() );
 			TestDictionaryKeyCore( context, "first-property", "second-property", "third-property", "fourth-property", asIs: false, isAsync: false );
 		}
@@ -9147,7 +9147,7 @@ namespace MsgPack.Serialization
 		public void TestDictionaryKeyTransformer_Custom_Async()
 		{
 			var context = GetSerializationContext();
-			context.DictionarySerlaizationOptions.KeyTransformer = 
+			context.DictionarySerializationOptions.KeyTransformer = 
 				key => Regex.Replace( key, "[A-Z]", match => match.Index == 0 ? match.Value.ToLower() : "-" + match.Value.ToLower() );
 			TestDictionaryKeyCore( context, "first-property", "second-property", "third-property", "fourth-property", asIs: false, isAsync: true );
 		}


### PR DESCRIPTION
Fixes a typo in one of the public APIs. Since this is still prior to the 1.0 release, now is the time to fix these things :).