### PR TITLE
Add missing dependencies to NuGet packages

### DIFF
--- a/MsgPack.nuspec
+++ b/MsgPack.nuspec
@@ -76,6 +76,12 @@ This package provides MessagePack serialization/deserialization APIs. This pacak
         <dependency id="System.Text.RegularExpressions" version="4.1.0" />
         <dependency id="System.Threading" version="4.0.11" />
       </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.CodeDom" version="4.4.0" exclude="Build,Analyzers" />
+        <dependency id="System.Numerics.Vectors" version="4.3.0" exclude="Build,Analyzers" />
+        <dependency id="System.Reflection.Emit" version="4.3.0" exclude="Build,Analyzers" />
+        <dependency id="System.Reflection.Emit.LightWeight" version="4.3.0" exclude="Build,Analyzers" />
+      </group>
       <group targetFramework="uap10.0">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="5.2.2" />
         <dependency id="System.Collections.NonGeneric" version="4.0.1" />


### PR DESCRIPTION
Duplicate of #306 for `master`.

Add missing .NETStandard2.0 dependencies to NuGet package. The `System.CodeDom` reference, in particular, is causing [this issue](https://github.com/DataDog/dd-trace-csharp/issues/186) and probably #283, too.