### PR TITLE
LIB\NET45\MsgPack.XML TYPO

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -119,4 +119,3 @@ Release 0.4.5
 
   NEW FEATURES
   * System.Runtime.Serialization assembly is not required now (pull-request #29). Thanks @takeshik!
-  * Read only members now ignored (issue #28, pull-request #30). hanks @takeshik!

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -105,3 +105,9 @@ Release 0.4.3 - 2014/3/22
   * Fix creating serializer for IEnumerable<T> (and not IList<T> nor IDictionary<TKey, TValue>) causes NullReferenceException.
   * Fix built-in object serializer cannot deserialize array/map correctly.
   * Fix PackerUnpackerExtensions.Pack<T>() ignore Default serialization context and uses brand-new instance every time.
+
+Release 0.4.4 - 2014/4/13
+
+  BUG FIXES
+  * Fix creating serializer for IDIctionary<TKey, TValue> causes NullReferenceException.
+  * Fix serializers' default constructor IL (it is not used in the library, but can be called via reflection).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -98,3 +98,10 @@ Release 0.4.2 - 2014/3/17
 
   BUG FIXES
   * Add API to re-register serializer (issue #24). It allows you to override default(built-in) serializer as you like.
+
+Release 0.4.3 - 2014/3/22
+
+  BUG FIXES
+  * Fix creating serializer for IEnumerable<T> (and not IList<T> nor IDictionary<TKey, TValue>) causes NullReferenceException.
+  * Fix built-in object serializer cannot deserialize array/map correctly.
+  * Fix PackerUnpackerExtensions.Pack<T>() ignore Default serialization context and uses brand-new instance every time.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -111,3 +111,8 @@ Release 0.4.4 - 2014/4/13
   BUG FIXES
   * Fix creating serializer for IDictionary<TKey, TValue> causes NullReferenceException.
   * Fix serializers' default constructor IL (it is not used in the library, but can be called via reflection).
+
+Release 0.4.5
+
+  BUF FIXES
+  * Fix creating serializer for abstract dictionary types causes exception in WinRT.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -87,3 +87,9 @@ Release 0.4 - 2013/10/6
   * Nullable<MessagePack> based unpacker API is deprecated becaue of their poor performance. You should use fast non-nullable APIs instead (properties/methods with 'Data' suffixes).
   * This version is tested on .NET 4.5 and Mono 2.10.8.1.
 
+Release 0.4.1 - 2013/12/07
+
+  BUG FIXES
+  * Fix Readme code error (issue #20.)
+  * Fix MessagePack.Create<T>() might fail due to type lock synchronization does not coordinate multiple threads (issue #19.)
+  * Fix deserializing as MessagePackObject fails when unpacking data is list or map (issue #13.)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -93,3 +93,8 @@ Release 0.4.1 - 2013/12/07
   * Fix Readme code error (issue #20.)
   * Fix MessagePack.Create<T>() might fail due to type lock synchronization does not coordinate multiple threads (issue #19.)
   * Fix deserializing as MessagePackObject fails when unpacking data is list or map (issue #13.)
+
+Release 0.4.2 - 2014/3/17
+
+  BUG FIXES
+  * Add API to re-register serializer (issue #24). It allows you to override default(built-in) serializer as you like.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -116,3 +116,7 @@ Release 0.4.5
 
   BUF FIXES
   * Fix creating serializer for abstract dictionary types causes exception in WinRT.
+
+  NEW FEATURES
+  * System.Runtime.Serialization assembly is not required now (pull-request #29). Thanks @takeshik!
+  * Read only members now ignored (issue #28, pull-request #30). hanks @takeshik!

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -109,5 +109,5 @@ Release 0.4.3 - 2014/3/22
 Release 0.4.4 - 2014/4/13
 
   BUG FIXES
-  * Fix creating serializer for IDIctionary<TKey, TValue> causes NullReferenceException.
+  * Fix creating serializer for IDictionary<TKey, TValue> causes NullReferenceException.
   * Fix serializers' default constructor IL (it is not used in the library, but can be called via reflection).

--- a/MsgPack.nuspec
+++ b/MsgPack.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>MsgPack.Cli</id>
     <title>MessagePack for CLI</title>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <authors>FUJIWARA, Yusuke</authors>
     <owners>FUJIWARA, Yusuke</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
@@ -12,8 +12,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MessagePack is fast, compact, and interoperable binary serialization format.
 This library provides MessagePack serialization/deserialization APIs.</description>
-    <releaseNotes>0.4 release improves performance, adds str8 support, ext type support, improved serializer generator API, new abstract collection support, and some bug fixes. This release includes some minor bug fixes.</releaseNotes>
-    <copyright>Copyright 2010-2013 FUJIWARA, Yusuke, all rights reserved.</copyright>
+    <releaseNotes>0.4 release improves performance, adds str8 support, ext type support, improved serializer generator API, new abstract collection support, and some bug fixes. This release includes a bug fix related to overriding built-in serializers.</releaseNotes>
+    <copyright>Copyright 2010-2014 FUJIWARA, Yusuke, all rights reserved.</copyright>
     <tags>Serialization MessagePack MsgPack Formatter Binary Serializer</tags>
     <dependencies />
   </metadata>

--- a/MsgPack.nuspec
+++ b/MsgPack.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>MsgPack.Cli</id>
     <title>MessagePack for CLI</title>
-    <version>0.4.3</version>
+    <version>0.4.4</version>
     <authors>FUJIWARA, Yusuke</authors>
     <owners>FUJIWARA, Yusuke</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MessagePack is fast, compact, and interoperable binary serialization format.
 This library provides MessagePack serialization/deserialization APIs.</description>
-    <releaseNotes>0.4 release improves performance, adds str8 support, ext type support, improved serializer generator API, new abstract collection support, and some bug fixes. This release includes bug fixes related to some collection types.</releaseNotes>
+    <releaseNotes>0.4 release improves performance, adds str8 support, ext type support, improved serializer generator API, new abstract collection support, and some bug fixes. This release includes bug fixes related to some collection interface types.</releaseNotes>
     <copyright>Copyright 2010-2014 FUJIWARA, Yusuke, all rights reserved.</copyright>
     <tags>Serialization MessagePack MsgPack Formatter Binary Serializer</tags>
     <dependencies />

--- a/MsgPack.nuspec
+++ b/MsgPack.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>MsgPack.Cli</id>
     <title>MessagePack for CLI</title>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
     <authors>FUJIWARA, Yusuke</authors>
     <owners>FUJIWARA, Yusuke</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MessagePack is fast, compact, and interoperable binary serialization format.
 This library provides MessagePack serialization/deserialization APIs.</description>
-    <releaseNotes>This release improves performance, adds str8 support, ext type support, improved serializer generator API, new abstract collection support, and some bug fixes.</releaseNotes>
+    <releaseNotes>0.4 release improves performance, adds str8 support, ext type support, improved serializer generator API, new abstract collection support, and some bug fixes. This release includes some minor bug fixes.</releaseNotes>
     <copyright>Copyright 2010-2013 FUJIWARA, Yusuke, all rights reserved.</copyright>
     <tags>Serialization MessagePack MsgPack Formatter Binary Serializer</tags>
     <dependencies />

--- a/MsgPack.nuspec
+++ b/MsgPack.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>MsgPack.Cli</id>
     <title>MessagePack for CLI</title>
-    <version>0.4.2</version>
+    <version>0.4.3</version>
     <authors>FUJIWARA, Yusuke</authors>
     <owners>FUJIWARA, Yusuke</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MessagePack is fast, compact, and interoperable binary serialization format.
 This library provides MessagePack serialization/deserialization APIs.</description>
-    <releaseNotes>0.4 release improves performance, adds str8 support, ext type support, improved serializer generator API, new abstract collection support, and some bug fixes. This release includes a bug fix related to overriding built-in serializers.</releaseNotes>
+    <releaseNotes>0.4 release improves performance, adds str8 support, ext type support, improved serializer generator API, new abstract collection support, and some bug fixes. This release includes bug fixes related to some collection types.</releaseNotes>
     <copyright>Copyright 2010-2014 FUJIWARA, Yusuke, all rights reserved.</copyright>
     <tags>Serialization MessagePack MsgPack Formatter Binary Serializer</tags>
     <dependencies />

--- a/README.md
+++ b/README.md
@@ -7,15 +7,27 @@ This library can be used from ALL CLS compliant languages such as C#, F#, Visual
 
 ## Usage
 
+You can serialize/deserialize objects as following:
+1. Create serializer via `MessagePackSerializer.Create` generic method. This method creates dependent types serializers as well.
+1. Invoke serializer as following:
+** `Pack` method with destination `Stream` and target object for serialization.
+** `Unpack` method with source `Stream`.
+
 ```c#
-var serializer = MessagePackSerializer<T>.Create();
+// Creates serializer.
+var serializer = MessagePackSerializer.Create<T>();
+// Pack obj to stream.
 serializer.Pack(stream, obj);
+// Unpack from stream.
 var unpackedObject = serializer.Unpack(stream);
 ```
 
 ```vb
-Dim serializer = MessagePackSerializer(Of T).Create()
+' Creates serializer.
+Dim serializer = MessagePackSerializer.Create(Of T)()
+' Pack obj to stream.
 serializer.Pack(stream, obj)
+' Unpack from stream.
 Dim unpackedObject = serializer.Unpack(stream)
 ```
 

--- a/src/CommonAssemblyInfo.Pack.cs
+++ b/src/CommonAssemblyInfo.Pack.cs
@@ -38,4 +38,4 @@ using System.Runtime.InteropServices;
 //   Build : Bug fixes and improvements, which does not break API contract, but may break some code depends on internal implementation behaviors.
 //           For example, some programs use reflection to retrieve private fields, analyse human readable exception messages or stack trace, or so.
 //   Revision : Not used. It might be used to indicate target platform.
-[assembly: AssemblyInformationalVersion( "0.4.0" )]
+[assembly: AssemblyInformationalVersion( "0.4.1" )]

--- a/src/MsgPack.Mono/MsgPack.Mono.csproj
+++ b/src/MsgPack.Mono/MsgPack.Mono.csproj
@@ -41,7 +41,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/MsgPack.Mono/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.Mono/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Security;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 [assembly: SecurityRules( SecurityRuleSet.Level2, SkipVerificationInFullTrust = true )]
 [assembly: AllowPartiallyTrustedCallers]

--- a/src/MsgPack.Net35/MsgPack.Net35.csproj
+++ b/src/MsgPack.Net35/MsgPack.Net35.csproj
@@ -43,7 +43,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/MsgPack.Net35/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.Net35/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Security;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2013" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 [assembly: AllowPartiallyTrustedCallers]
 

--- a/src/MsgPack.Net35/Tuple`n.cs
+++ b/src/MsgPack.Net35/Tuple`n.cs
@@ -2,7 +2,7 @@
 //
 // MessagePack for CLI
 //
-// Copyright (C) 2010-2012 FUJIWARA, Yusuke
+// Copyright (C) 2010-2013 FUJIWARA, Yusuke
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -37,6 +37,11 @@ namespace System
 		public static Tuple<T1, T2, T3, T4> Create<T1, T2, T3, T4>( T1 item1, T2 item2, T3 item3, T4 item4 )
 		{
 			return new Tuple<T1, T2, T3, T4>( item1, item2, item3, item4 );
+		}
+
+		public static Tuple<T1, T2, T3, T4, T5> Create<T1, T2, T3, T4, T5>( T1 item1, T2 item2, T3 item3, T4 item4, T5 item5 )
+		{
+			return new Tuple<T1, T2, T3, T4, T5>( item1, item2, item3, item4, item5 );
 		}
 	}
 #if !WINDOWS_PHONE
@@ -128,6 +133,72 @@ namespace System
 			buffer.Append( this._item3 );
 			buffer.Append( ", " );
 			buffer.Append( this._item4 );
+			return buffer.ToString();
+		}
+	}
+#if !WINDOWS_PHONE
+	[Serializable]
+#endif
+	internal class Tuple<T1, T2, T3, T4, T5>
+	{
+		private readonly T1 _item1;
+		
+		public T1 Item1
+		{
+			get { return this._item1; }
+		}
+		private readonly T2 _item2;
+		
+		public T2 Item2
+		{
+			get { return this._item2; }
+		}
+		private readonly T3 _item3;
+		
+		public T3 Item3
+		{
+			get { return this._item3; }
+		}
+		private readonly T4 _item4;
+		
+		public T4 Item4
+		{
+			get { return this._item4; }
+		}
+		private readonly T5 _item5;
+		
+		public T5 Item5
+		{
+			get { return this._item5; }
+		}
+		public Tuple(
+			T1 item1,
+			T2 item2,
+			T3 item3,
+			T4 item4,
+			T5 item5
+		)
+		{
+			this._item1 = item1;
+			this._item2 = item2;
+			this._item3 = item3;
+			this._item4 = item4;
+			this._item5 = item5;
+		}
+		
+		public override string ToString()
+		{
+			var buffer = new StringBuilder();
+			buffer.Append( '(' );
+			buffer.Append( this._item1 );
+			buffer.Append( ", " );
+			buffer.Append( this._item2 );
+			buffer.Append( ", " );
+			buffer.Append( this._item3 );
+			buffer.Append( ", " );
+			buffer.Append( this._item4 );
+			buffer.Append( ", " );
+			buffer.Append( this._item5 );
 			return buffer.ToString();
 		}
 	}

--- a/src/MsgPack.Net35/Tuple`n.tt
+++ b/src/MsgPack.Net35/Tuple`n.tt
@@ -30,13 +30,13 @@
 <#
 // This file defines Tuple<...> for compatibility.
 var __typeName = "Tuple";
-var __arities = new []{ 2, 4 };
+var __arities = new []{ 2, 4, 5 };
 #>
 #region -- License Terms --
 //
 // MessagePack for CLI
 //
-// Copyright (C) 2010-2012 FUJIWARA, Yusuke
+// Copyright (C) 2010-2013 FUJIWARA, Yusuke
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.

--- a/src/MsgPack.Serialization.Silverlight.4/MsgPack.Serialization.Silverlight.4.csproj
+++ b/src/MsgPack.Serialization.Silverlight.4/MsgPack.Serialization.Silverlight.4.csproj
@@ -57,7 +57,6 @@
     <Reference Include="System.Numerics, Version=2.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="system" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows" />

--- a/src/MsgPack.Serialization.Silverlight.4/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.Serialization.Silverlight.4/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 #if DEBUG || PERFORMANCE_TEST
 [assembly: InternalsVisibleTo( "MsgPack.Silverlight.UnitTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a967de8de9d45380b93a6aa56f64fc2cb2d3c9d4b400e00de01f31ba9e15cf5ca95926dbf8760cce413eabd711e23df0c133193a570da8a3bb1bdc00ef170fccb2bc033266fa5346442c9cf0b071133d5b484845eab17095652aeafeeb71193506b8294d9c8c91e3fd01cc50bdbc2d0eb78dd655bb8cd0bd3cdbbcb192549cb4" )]

--- a/src/MsgPack.Serialization.Silverlight.5/MsgPack.Serialization.Silverlight.5.csproj
+++ b/src/MsgPack.Serialization.Silverlight.5/MsgPack.Serialization.Silverlight.5.csproj
@@ -56,7 +56,6 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System.Numerics, Version=5.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows" />
     <Reference Include="system" />
     <Reference Include="System.Core" />

--- a/src/MsgPack.Serialization.Silverlight.5/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.Serialization.Silverlight.5/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 #if DEBUG || PERFORMANCE_TEST
 [assembly: InternalsVisibleTo( "MsgPack.Silverlight.UnitTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a967de8de9d45380b93a6aa56f64fc2cb2d3c9d4b400e00de01f31ba9e15cf5ca95926dbf8760cce413eabd711e23df0c133193a570da8a3bb1bdc00ef170fccb2bc033266fa5346442c9cf0b071133d5b484845eab17095652aeafeeb71193506b8294d9c8c91e3fd01cc50bdbc2d0eb78dd655bb8cd0bd3cdbbcb192549cb4" )]

--- a/src/MsgPack.Serialization.WinRT/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.Serialization.WinRT/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 #if DEBUG || PERFORMANCE_TEST
 [assembly: InternalsVisibleTo( "MsgPack.UnitTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a967de8de9d45380b93a6aa56f64fc2cb2d3c9d4b400e00de01f31ba9e15cf5ca95926dbf8760cce413eabd711e23df0c133193a570da8a3bb1bdc00ef170fccb2bc033266fa5346442c9cf0b071133d5b484845eab17095652aeafeeb71193506b8294d9c8c91e3fd01cc50bdbc2d0eb78dd655bb8cd0bd3cdbbcb192549cb4" )]

--- a/src/MsgPack.Serialization.WindowsPhone.7.1/MsgPack.Serialization.WindowsPhone.7.1.csproj
+++ b/src/MsgPack.Serialization.WindowsPhone.7.1/MsgPack.Serialization.WindowsPhone.7.1.csproj
@@ -42,7 +42,6 @@
     <DocumentationFile>..\..\bin\sl4-windowsphone71\MsgPack.Serialization.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows" />
     <Reference Include="system" />
     <Reference Include="System.Core" />

--- a/src/MsgPack.Serialization.WindowsPhone.7.1/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.Serialization.WindowsPhone.7.1/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 #if DEBUG || PERFORMANCE_TEST
 [assembly: InternalsVisibleTo( "MsgPack.WindowsPhone.UnitTest" )]

--- a/src/MsgPack.Silverlight.4/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.Silverlight.4/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 #if DEBUG || PERFORMANCE_TEST
 [assembly: InternalsVisibleTo( "MsgPack.Silverlight.UnitTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a967de8de9d45380b93a6aa56f64fc2cb2d3c9d4b400e00de01f31ba9e15cf5ca95926dbf8760cce413eabd711e23df0c133193a570da8a3bb1bdc00ef170fccb2bc033266fa5346442c9cf0b071133d5b484845eab17095652aeafeeb71193506b8294d9c8c91e3fd01cc50bdbc2d0eb78dd655bb8cd0bd3cdbbcb192549cb4" )]

--- a/src/MsgPack.Silverlight.5/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.Silverlight.5/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 #if DEBUG || PERFORMANCE_TEST
 [assembly: InternalsVisibleTo( "MsgPack.Silverlight.UnitTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a967de8de9d45380b93a6aa56f64fc2cb2d3c9d4b400e00de01f31ba9e15cf5ca95926dbf8760cce413eabd711e23df0c133193a570da8a3bb1bdc00ef170fccb2bc033266fa5346442c9cf0b071133d5b484845eab17095652aeafeeb71193506b8294d9c8c91e3fd01cc50bdbc2d0eb78dd655bb8cd0bd3cdbbcb192549cb4" )]

--- a/src/MsgPack.WinRT/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.WinRT/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 #if DEBUG || PERFORMANCE_TEST
 [assembly: InternalsVisibleTo( "MsgPack.UnitTest, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a967de8de9d45380b93a6aa56f64fc2cb2d3c9d4b400e00de01f31ba9e15cf5ca95926dbf8760cce413eabd711e23df0c133193a570da8a3bb1bdc00ef170fccb2bc033266fa5346442c9cf0b071133d5b484845eab17095652aeafeeb71193506b8294d9c8c91e3fd01cc50bdbc2d0eb78dd655bb8cd0bd3cdbbcb192549cb4" )]

--- a/src/MsgPack.WindowsPhone.7.1/Properties/AssemblyInfo.cs
+++ b/src/MsgPack.WindowsPhone.7.1/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 #if DEBUG || PERFORMANCE_TEST
 [assembly: InternalsVisibleTo( "MsgPack.WindowsPhone.UnitTest" )]

--- a/src/MsgPack/MsgPack.csproj
+++ b/src/MsgPack/MsgPack.csproj
@@ -91,7 +91,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\CommonAssemblyInfo.cs">

--- a/src/MsgPack/PackerUnpackerExtensions.cs
+++ b/src/MsgPack/PackerUnpackerExtensions.cs
@@ -130,7 +130,7 @@ namespace MsgPack
 
 			Contract.EndContractBlock();
 
-			PackObjectCore( source, value, new SerializationContext() );
+			PackObjectCore( source, value, SerializationContext.Default );
 		}
 
 		/// <summary>

--- a/src/MsgPack/Properties/AssemblyInfo.cs
+++ b/src/MsgPack/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Security;
 [assembly: AssemblyCopyright( "Copyright © FUJIWARA, Yusuke 2010-2012" )]
 
 
-[assembly: AssemblyFileVersion( "0.4.1297.568" )]
+[assembly: AssemblyFileVersion( "0.4.1435.1085" )]
 
 [assembly: SecurityRules( SecurityRuleSet.Level2, SkipVerificationInFullTrust = true )]
 [assembly: AllowPartiallyTrustedCallers]

--- a/src/MsgPack/Serialization/DataMemberContract.cs
+++ b/src/MsgPack/Serialization/DataMemberContract.cs
@@ -97,25 +97,31 @@ namespace MsgPack.Serialization
 		}
 
 		/// <summary>
-		///		Initializes a new instance of the <see cref="DataMemberContract"/> struct from <see cref="DataMemberAttribute"/>.
+		///		Initializes a new instance of the <see cref="DataMemberContract"/> struct.
 		/// </summary>
 		/// <param name="member">The target member.</param>
-		/// <param name="attribute">The data contract member attribute. This value can be <c>null</c>.</param>
-		public DataMemberContract( MemberInfo member, DataMemberAttribute attribute )
+		/// <param name="name">The name of member.</param>
+		/// <param name="nilImplication">The implication of the nil value for the member.</param>
+		/// <param name="id">The ID of the member. This value cannot be negative and must be unique in the type.</param>
+		public DataMemberContract( MemberInfo member, string name, NilImplication nilImplication, int? id )
 		{
 			Contract.Requires( member != null );
-			Contract.Requires( attribute != null );
 
-			this._name = String.IsNullOrEmpty( attribute.Name ) ? member.Name : attribute.Name;
-			this._nilImplication = Serialization.NilImplication.MemberDefault;
-			this._id = attribute.Order;
+			if ( id < 0 )
+			{
+				throw new SerializationException( String.Format( CultureInfo.CurrentCulture, "The member ID cannot be negative. The member is '{0}' in the '{1}' type.", member.Name, member.DeclaringType ) );
+			}
+
+			this._name = String.IsNullOrEmpty( name ) ? member.Name : name;
+			this._nilImplication = nilImplication;
+			this._id = id ?? UnspecifiedId;
 		}
 
 		/// <summary>
 		///		Initializes a new instance of the <see cref="DataMemberContract"/> struct from <see cref="MessagePackMemberAttribute"/>.
 		/// </summary>
 		/// <param name="member">The target member.</param>
-		/// <param name="attribute">The MessagePack member attribute. This value can be <c>null</c>.</param>
+		/// <param name="attribute">The MessagePack member attribute.</param>
 		public DataMemberContract( MemberInfo member, MessagePackMemberAttribute attribute )
 		{
 			Contract.Requires( member != null );

--- a/src/MsgPack/Serialization/DefaultSerializers/MsgPack_MessagePackObjectMessagePackSerializer.cs
+++ b/src/MsgPack/Serialization/DefaultSerializers/MsgPack_MessagePackObjectMessagePackSerializer.cs
@@ -34,7 +34,14 @@ namespace MsgPack.Serialization.DefaultSerializers
 
 		protected internal sealed override MessagePackObject UnpackFromCore( Unpacker unpacker )
 		{
-			return unpacker.LastReadData;
+			if ( unpacker.IsArrayHeader || unpacker.IsMapHeader )
+			{
+				return unpacker.UnpackSubtreeData();
+			}
+			else
+			{
+				return unpacker.LastReadData;
+			}
 		}
 	}
 }

--- a/src/MsgPack/Serialization/EmittingSerializers/FieldBasedSerializerEmitter.cs
+++ b/src/MsgPack/Serialization/EmittingSerializers/FieldBasedSerializerEmitter.cs
@@ -233,7 +233,7 @@ namespace MsgPack.Serialization.EmittingSerializers
 					// : this(null)
 					il.Emit( OpCodes.Ldarg_0 );
 					il.Emit( OpCodes.Ldnull );
-					il.Emit( OpCodes.Call, this._defaultConstructorBuilder );
+					il.Emit( OpCodes.Call, this._contextConstructorBuilder );
 					il.Emit( OpCodes.Ret );
 				}
 

--- a/src/MsgPack/Serialization/ExpressionSerializers/MapExpressionMessagePackSerializer.cs
+++ b/src/MsgPack/Serialization/ExpressionSerializers/MapExpressionMessagePackSerializer.cs
@@ -64,11 +64,17 @@ namespace MsgPack.Serialization.ExpressionSerializers
 			this._valueSerializer = traits.ElementType.GetIsGenericType() ? context.GetSerializer( traits.ElementType.GetGenericArguments()[ 1 ] ) : context.GetSerializer( typeof( MessagePackObject ) );
 			this._getCount = ExpressionSerializerLogics.CreateGetCount<T>( traits );
 
-			var constructor = ExpressionSerializerLogics.GetCollectionConstructor( context, typeof( T ) );
+			var targetType = typeof( T );
+			if ( targetType.GetIsAbstract() || targetType.GetIsInterface() )
+			{
+				targetType = context.DefaultCollectionTypes.GetConcreteType( targetType );
+			}
+
+			var constructor = ExpressionSerializerLogics.GetCollectionConstructor( context, targetType );
 
 			if ( constructor == null )
 			{
-				this._createInstance = () => { throw SerializationExceptions.NewTargetDoesNotHavePublicDefaultConstructorNorInitialCapacity( typeof( T ) ); };
+				this._createInstance = () => { throw SerializationExceptions.NewTargetDoesNotHavePublicDefaultConstructorNorInitialCapacity( targetType ); };
 				this._createInstanceWithCapacity = null;
 			}
 			else if ( constructor.GetParameters().Length == 1 )

--- a/src/MsgPack/Serialization/ReflectionExtensions.cs
+++ b/src/MsgPack/Serialization/ReflectionExtensions.cs
@@ -144,7 +144,22 @@ namespace MsgPack.Serialization
 			Type idictionaryT = null;
 			Type ienumerable = null;
 			Type idictionary = null;
-			foreach ( var type in source.FindInterfaces( FilterCollectionType, null ) )
+
+			var sourceInterfaces = source.FindInterfaces( FilterCollectionType, null );
+			if ( source.GetIsInterface() && FilterCollectionType( source, null ) )
+			{
+				var originalSourceInterfaces = sourceInterfaces.ToArray();
+				var concatenatedSourceInterface = new Type[ originalSourceInterfaces.Length + 1 ];
+				concatenatedSourceInterface[ 0 ] = source;
+				for ( int i = 0; i < originalSourceInterfaces.Length; i++ )
+				{
+					concatenatedSourceInterface[ i + 1 ] = originalSourceInterfaces[ i ];
+				}
+
+				sourceInterfaces = concatenatedSourceInterface;
+			}
+
+			foreach ( var type in sourceInterfaces )
 			{
 				if ( type == typeof( IDictionary<MessagePackObject, MessagePackObject> ) )
 				{

--- a/src/MsgPack/Serialization/ReflectionExtensions.cs
+++ b/src/MsgPack/Serialization/ReflectionExtensions.cs
@@ -121,7 +121,10 @@ namespace MsgPack.Serialization
 
 				// Block to limit variable scope
 				{
-					var ienumetaorT = getEnumerator.ReturnType.GetInterfaces().FirstOrDefault( @interface => @interface.GetIsGenericType() && @interface.GetGenericTypeDefinition() == typeof( IEnumerator<> ) );
+					var ienumetaorT =
+						IsIEnumeratorT(getEnumerator.ReturnType)
+						? getEnumerator.ReturnType
+						: getEnumerator.ReturnType.GetInterfaces().FirstOrDefault( IsIEnumeratorT );
 					if ( ienumetaorT != null )
 					{
 						var elementType = ienumetaorT.GetGenericArguments()[ 0 ];
@@ -130,7 +133,7 @@ namespace MsgPack.Serialization
 								CollectionKind.Array,
 								GetAddMethod( source, elementType ),
 								getEnumerator,
-								null,
+								GetCollectionTCountProperty( source, elementType ),
 								elementType
 							);
 					}
@@ -370,6 +373,10 @@ namespace MsgPack.Serialization
 #endif
 		}
 
+		private static bool IsIEnumeratorT( Type @interface )
+		{
+			return @interface.GetIsGenericType() && @interface.GetGenericTypeDefinition() == typeof( IEnumerator<> );
+		}
 #if WINDOWS_PHONE
 		public static IEnumerable<Type> FindInterfaces( this Type source, Func<Type, object, bool> filter, object criterion )
 		{

--- a/src/MsgPack/Serialization/SerializationExceptions.cs
+++ b/src/MsgPack/Serialization/SerializationExceptions.cs
@@ -227,12 +227,17 @@ namespace MsgPack.Serialization
 		}
 
 		/// <summary>
+		///		<see cref="MethodInfo"/> of <see cref="NewMissingAddMethod"/> method.
+		/// </summary>
+		internal static readonly MethodInfo NewMissingAddMethodMethod = FromExpression.ToMethod( ( Type type ) => NewMissingAddMethod( type ) );
+
+		/// <summary>
 		///		<strong>This is intended to MsgPack for CLI internal use. Do not use this type from application directly.</strong>
 		///		Returns new exception to notify that target collection type does not declare appropriate Add(T) method.
 		/// </summary>
 		/// <param name="type">The target type.</param>
 		/// <returns><see cref="Exception"/> instance. It will not be <c>null</c>.</returns>
-		internal static Exception NewMissingAddMethod( Type type )
+		public static Exception NewMissingAddMethod( Type type )
 		{
 			Contract.Requires( type != null );
 			Contract.Ensures( Contract.Result<Exception>() != null );

--- a/src/MsgPack/Serialization/SerializerRepository.cs
+++ b/src/MsgPack/Serialization/SerializerRepository.cs
@@ -119,6 +119,24 @@ namespace MsgPack.Serialization
 			return this._repository.Register( typeof( T ), serializer, allowOverwrite: false );
 		}
 
+		/// <summary>
+		///		Registers a <see cref="MessagePackSerializer{T}"/> forcibley.
+		/// </summary>
+		/// <typeparam name="T">The type of serialization target.</typeparam>
+		/// <param name="serializer"><see cref="MessagePackSerializer{T}"/> instance.</param>
+		/// <exception cref="ArgumentNullException">
+		///		<paramref name="serializer"/> is <c>null</c>.
+		/// </exception>
+		public void RegisterOverride<T>( MessagePackSerializer<T> serializer )
+		{
+			if ( serializer == null )
+			{
+				throw new ArgumentNullException( "serializer" );
+			}
+
+			this._repository.Register( typeof( T ), serializer, allowOverwrite: true );
+		}
+
 		private static readonly Dictionary<PackerCompatibilityOptions, SerializerRepository> _defaults =
 			new Dictionary<PackerCompatibilityOptions, SerializerRepository>( 4 )
 			{

--- a/test/MsgPack.UnitTest/PackerTest.Pack.Miscs.cs
+++ b/test/MsgPack.UnitTest/PackerTest.Pack.Miscs.cs
@@ -24,6 +24,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+
+using MsgPack.Serialization;
 #if !MSTEST
 using NUnit.Framework;
 #else
@@ -265,12 +267,16 @@ namespace MsgPack
 		}
 
 		[Test]
-		public void TestPackItems_NotNullEnumerable_Fail()
+		public void TestPackItems_NotNullEnumerable_AsArray()
 		{
 			using ( var buffer = new MemoryStream() )
 			using ( var packer = Packer.Create( buffer ) )
 			{
-				Assert.Throws<SerializationException>( () => packer.Pack( Enumerable.Range( 1, 3 ) ) );
+				packer.Pack( Enumerable.Range( 1, 3 ) );
+				Assert.AreEqual(
+					new byte[] { 0x93, 1, 2, 3 },
+					buffer.ToArray()
+				);
 			}
 		}
 

--- a/test/MsgPack.UnitTest/Serialization/AutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/AutoMessagePackSerializerTest.cs
@@ -1072,6 +1072,58 @@ namespace MsgPack.Serialization
 #endif
 		}
 
+		[Test]
+		public void TestIssue25_Plain()
+		{
+			var hasEnumerable = new HasEnumerable { Numbers = new[] { 1, 2 } };
+			var target = MessagePackSerializer.Create<HasEnumerable>( this.GetSerializationContext() );
+			using ( var buffer = new MemoryStream() )
+			{
+				target.Pack( buffer, hasEnumerable );
+				buffer.Position = 0;
+				var result = target.Unpack( buffer );
+				var resultNumbers = result.Numbers.ToArray();
+				Assert.That( resultNumbers.Length, Is.EqualTo( 2 ) );
+				Assert.That( resultNumbers[ 0 ], Is.EqualTo( 1 ) );
+				Assert.That( resultNumbers[ 1 ], Is.EqualTo( 2 ) );
+			}
+		}
+
+		public class HasEnumerable
+		{
+			public IEnumerable<int> Numbers { get; set; }
+		}
+
+		[Test]
+		public void TestIssue25_SelfComposite()
+		{
+			SerializationContext serializationContext =
+				SerializationContext.Default;
+			try
+			{
+
+				serializationContext.Serializers.Register( new PersonSerializer() );
+				serializationContext.Serializers.Register( new ChildrenSerializer() );
+
+				object[] array = new object[] { new Person { Name = "Joe" }, 3 };
+
+				MessagePackSerializer<object[]> context =
+					serializationContext.GetSerializer<object[]>();
+
+				byte[] packed = context.PackSingleObject( array ); // throws NullReferenceException
+				object[] unpacked = context.UnpackSingleObject( packed );
+
+				Assert.That( unpacked.Length, Is.EqualTo( 2 ) );
+				Assert.That( ( ( MessagePackObject )unpacked[ 0 ] ).AsDictionary()[ "Name" ].AsString(), Is.EqualTo( "Joe" ) );
+				Assert.That( ( ( MessagePackObject )unpacked[ 0 ] ).AsDictionary()[ "Children" ].IsNil );
+				Assert.That( ( MessagePackObject )unpacked[ 1 ], Is.EqualTo( new MessagePackObject( 3 ) ) );
+			}
+			finally
+			{
+				SerializationContext.Default = new SerializationContext();
+			}
+		}
+
 		public struct TestValueType
 		{
 			public string StringField;
@@ -1290,7 +1342,7 @@ namespace MsgPack.Serialization
 
 			public void Add( KeyValuePair<TKey, TValue> item )
 			{
-				throw new NotImplementedException();
+				this.Add( item.Key, item.Value );
 			}
 
 			public void Clear()
@@ -1410,5 +1462,120 @@ namespace MsgPack.Serialization
 		{
 			public Stream NonCollection { get; set; }
 		}
+		// Issue #25
+
+		public class Person : IEnumerable<Person>
+		{
+			public string Name { get; set; }
+
+			internal IEnumerable<Person> Children { get; set; }
+
+			public IEnumerator<Person> GetEnumerator()
+			{
+				return Children.GetEnumerator();
+			}
+
+			IEnumerator IEnumerable.GetEnumerator()
+			{
+				return GetEnumerator();
+			}
+		}
+
+		public class PersonSerializer : MessagePackSerializer<Person>
+		{
+			protected internal override void PackToCore( Packer packer, Person objectTree )
+			{
+				packer.PackMapHeader( 2 );
+				packer.Pack( "Name" );
+				packer.Pack( objectTree.Name );
+				packer.Pack( "Children" );
+				if ( objectTree.Children == null )
+				{
+					packer.PackNull();
+				}
+				else
+				{
+					this.PackPeople( packer, objectTree.Children );
+				}
+			}
+
+			internal void PackPeople( Packer packer, IEnumerable<Person> people )
+			{
+				var children = people.ToArray();
+
+				packer.PackArrayHeader( children.Length );
+				foreach ( var child in children )
+				{
+					this.PackTo( packer, child );
+				}
+			}
+
+			protected internal override Person UnpackFromCore( Unpacker unpacker )
+			{
+				Assert.That( unpacker.IsMapHeader );
+				Assert.That( unpacker.ItemsCount, Is.EqualTo( 2 ) );
+				var person = new Person();
+				for ( int i = 0; i < 2; i++ )
+				{
+					string key;
+					Assert.That( unpacker.ReadString( out key ) );
+					switch ( key )
+					{
+						case "Name":
+						{
+
+							string name;
+							Assert.That( unpacker.ReadString( out name ) );
+							person.Name = name;
+							break;
+						}
+						case "Children":
+						{
+							Assert.That( unpacker.Read() );
+							person.Children = this.UnpackPeople( unpacker );
+							break;
+						}
+					}
+				}
+
+				return person;
+			}
+
+			internal IEnumerable<Person> UnpackPeople( Unpacker unpacker )
+			{
+				Assert.That( unpacker.IsArrayHeader );
+				var itemsCount = ( int )unpacker.ItemsCount;
+				var people = new List<Person>( itemsCount );
+				for ( int i = 0; i < itemsCount; i++ )
+				{
+					people.Add( this.UnpackFrom( unpacker ) );
+				}
+
+				return people;
+			}
+		}
+
+		public class ChildrenSerializer : MessagePackSerializer<IEnumerable<Person>>
+		{
+			private readonly PersonSerializer _personSerializer = new PersonSerializer();
+
+			protected internal override void PackToCore( Packer packer, IEnumerable<Person> objectTree )
+			{
+				if ( objectTree is Person )
+				{
+					this._personSerializer.PackTo( packer, objectTree as Person );
+				}
+				else
+				{
+					this._personSerializer.PackPeople( packer, objectTree );
+				}
+			}
+
+			protected internal override IEnumerable<Person> UnpackFromCore( Unpacker unpacker )
+			{
+				return this._personSerializer.UnpackPeople( unpacker );
+			}
+		}
+
 	}
 }

--- a/test/MsgPack.UnitTest/Serialization/AutoMessagePackSerializerTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/AutoMessagePackSerializerTest.cs
@@ -1110,7 +1110,7 @@ namespace MsgPack.Serialization
 				MessagePackSerializer<object[]> context =
 					serializationContext.GetSerializer<object[]>();
 
-				byte[] packed = context.PackSingleObject( array ); // throws NullReferenceException
+				byte[] packed = context.PackSingleObject( array ); 
 				object[] unpacked = context.UnpackSingleObject( packed );
 
 				Assert.That( unpacked.Length, Is.EqualTo( 2 ) );
@@ -1532,7 +1532,10 @@ namespace MsgPack.Serialization
 						case "Children":
 						{
 							Assert.That( unpacker.Read() );
-							person.Children = this.UnpackPeople( unpacker );
+							if ( !unpacker.LastReadData.IsNil )
+							{
+								person.Children = this.UnpackPeople( unpacker );
+							}
 							break;
 						}
 					}

--- a/test/MsgPack.UnitTest/Serialization/MessagePackSerializerTTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/MessagePackSerializerTTest.cs
@@ -528,6 +528,20 @@ namespace MsgPack.Serialization
 			}
 		}
 
+		[Test]
+		public void TestIssue28()
+		{
+			var target = CreateTarget<WithReadOnlyProperty>();
+			using ( var buffer = new MemoryStream() )
+			{
+				var value = new WithReadOnlyProperty { Number = 123 };
+				target.Pack( buffer, value );
+				buffer.Position = 0;
+				var result = target.Unpack( buffer );
+				Assert.That( value.Number, Is.EqualTo( result.Number ) );
+			}
+		}
+
 		private void TestIssue10_Reader( Inner inner )
 		{
 			var serializer = MessagePackSerializer.Create<Outer>();
@@ -575,5 +589,11 @@ namespace MsgPack.Serialization
 			public byte[] Bytes = null;
 			public string C = "C";
 		}
+	}
+
+	public class WithReadOnlyProperty
+	{
+		public int Number { get; set; }
+		public string AsString{get { return this.Number.ToString(); }}
 	}
 }

--- a/test/MsgPack.UnitTest/Serialization/SerializationContextTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/SerializationContextTest.cs
@@ -23,7 +23,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 #if !MSTEST
@@ -199,7 +198,6 @@ namespace MsgPack.Serialization
 				var result = serializer.Unpack( buffer );
 				Assert.That( result, Is.EqualTo( dt ) );
 			}
-
 		}
 
 		private sealed class NetDateTimeSerializer : MessagePackSerializer<DateTime>

--- a/test/MsgPack.UnitTest/Serialization/SerializationContextTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/SerializationContextTest.cs
@@ -23,8 +23,12 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+
+using MsgPack.Serialization.DefaultSerializers;
+using MsgPack.Serialization.EmittingSerializers;
 #if !MSTEST
 using NUnit.Framework;
 #else
@@ -38,7 +42,7 @@ using Is = NUnit.Framework.Is;
 namespace MsgPack.Serialization
 {
 	[TestFixture]
-	[Timeout( 15000 )]
+	//[Timeout( 15000 )]
 	public class SerializationContextTest
 	{
 		[Test]
@@ -193,13 +197,65 @@ namespace MsgPack.Serialization
 			{
 				var serializer = MessagePackSerializer.Create<DateTime>( context );
 				var dt = new DateTime( 999999999999999999L, DateTimeKind.Utc );
-				serializer.Pack( buffer,dt );
+				serializer.Pack( buffer, dt );
 				buffer.Position = 0;
 				var result = serializer.Unpack( buffer );
 				Assert.That( result, Is.EqualTo( dt ) );
 			}
 		}
 
+		[Test]
+		public void TestIssue27_Dictionary()
+		{
+			var context = new SerializationContext();
+			using ( var buffer = new MemoryStream() )
+			{
+				var serializer = MessagePackSerializer.Create<IDictionary<String, String>>( context );
+				var dic = new Dictionary<string, string> { { "A", "A" } };
+				serializer.Pack( buffer, dic );
+				buffer.Position = 0;
+
+				var result = serializer.Unpack( buffer );
+
+				Assert.That( result.Count, Is.EqualTo( 1 ) );
+				Assert.That( result[ "A" ], Is.EqualTo( "A" ) );
+			}
+		}
+
+		[Test]
+		public void TestIssue27_List()
+		{
+			var context = new SerializationContext();
+			using ( var buffer = new MemoryStream() )
+			{
+				var serializer = MessagePackSerializer.Create<IList<String>>( context );
+				var list = new List<string> { "A" };
+				serializer.Pack( buffer, list );
+				buffer.Position = 0;
+				var result = serializer.Unpack( buffer );
+
+				Assert.That( result.Count, Is.EqualTo( 1 ) );
+				Assert.That( result[ 0 ], Is.EqualTo( "A" ) );
+			}
+		}
+
+
+		[Test]
+		public void TestIssue27_Collection()
+		{
+			var context = new SerializationContext();
+			using ( var buffer = new MemoryStream() )
+			{
+				var serializer = MessagePackSerializer.Create<ICollection<string>>( context );
+				var list = new List<string> { "A" };
+				serializer.Pack( buffer, list );
+				buffer.Position = 0;
+				var result = serializer.Unpack( buffer );
+
+				Assert.That( result.Count, Is.EqualTo( 1 ) );
+				Assert.That( result.First(), Is.EqualTo( "A" ) );
+			}
+		}
 		private sealed class NetDateTimeSerializer : MessagePackSerializer<DateTime>
 		{
 			protected internal override void PackToCore( Packer packer, DateTime objectTree )
@@ -281,7 +337,7 @@ namespace MsgPack.Serialization
 
 		public abstract class NewAbstractCollection<T> : Collection<T>
 		{
-			
+
 		}
 
 		public sealed class NewConcreteCollection<T> : NewAbstractCollection<T>

--- a/test/MsgPack.UnitTest/Serialization/SerializationContextTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/SerializationContextTest.cs
@@ -88,7 +88,9 @@ namespace MsgPack.Serialization
 		{
 			var context = new SerializationContext();
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( IList<> ) ), Is.EqualTo( typeof( List<> ) ) );
+#if !NETFX_35
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( ISet<> ) ), Is.EqualTo( typeof( HashSet<> ) ) );
+#endif
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( ICollection<> ) ), Is.EqualTo( typeof( List<> ) ) );
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( IEnumerable<> ) ), Is.EqualTo( typeof( List<> ) ) );
 			Assert.That( context.DefaultCollectionTypes.Get( typeof( IDictionary<,> ) ), Is.EqualTo( typeof( Dictionary<,> ) ) );

--- a/test/MsgPack.UnitTest/Serialization/SerializerGeneratorTest.cs
+++ b/test/MsgPack.UnitTest/Serialization/SerializerGeneratorTest.cs
@@ -241,7 +241,7 @@ namespace MsgPack.Serialization
 			{
 				var assembly = Assembly.LoadFrom( testAssemblyFile );
 				var types = assembly.GetTypes().Where( t => typeof( IMessagePackSerializer ).IsAssignableFrom( t ) ).ToList();
-				Assert.That( types.Count, Is.EqualTo( expectedSerializerTypeCounts ), String.Join( ", ", types ) );
+				Assert.That( types.Count, Is.EqualTo( expectedSerializerTypeCounts ), String.Join( ", ", types.Select( t => t.ToString() ).ToArray() ) );
 
 				var context = new SerializationContext( ( PackerCompatibilityOptions )packerCompatiblityOptions );
 


### PR DESCRIPTION
BUG REPORT

SOURCE FILE: MsgPack.Cli.0.6.8.nupkg

WINDOWS INSTALL PATH: C:\Program Files\PackageManagement\NuGet\Packages\MsgPack.Cli.0.6.8\lib\net45\MsgPack.XML

BUG COUNT: 1 of 870,899 bytes
CLASS:     TYPO
SEVERITY:  NONE

Line 1968 has a typo: 'othereise' should be 'otherwise'

1966            <param name="isImmutable">
1967            	<c>true</c> if the <paramref name="value"/> is immutable collection;
1968            	othereise, <c>false</c>.
1969            </param>

FIX:

Open file in PowerShell Administrator mode using install path.
Use Ctrl-G shortcut to get 'GoToLine Box'. Enter 1988. Correct 'e' to 'w'. Save the file.

Happy typos!