### PR TITLE
Changed "pacakge" to "package".

### DIFF
--- a/MsgPack.nuspec
+++ b/MsgPack.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://cli.msgpack.org/images/msgpack.ico</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>MessagePack is fast, compact, and interoperable binary serialization format.
-This package provides MessagePack serialization/deserialization APIs. This pacakge also supports Mono, Xamarin, .NET Core and Unity.</description>
+This package provides MessagePack serialization/deserialization APIs. This package also supports Mono, Xamarin, .NET Core and Unity.</description>
     <releaseNotes>This release includes .NET Core and Unity IL2CPP support, Xamarin iOS linker support, asynchronous serialization support, and various improvements and bug fixes reported in github issues.</releaseNotes>
     <copyright>Copyright 2010-2016 FUJIWARA, Yusuke, all rights reserved.</copyright>
     <tags>MsgPack MessagePack Serialization Formatter Serializer</tags>


### PR DESCRIPTION
Fixed a simple typo I saw when browsing .net packages.