### PR TITLE
Update Sample08_Polymorphism.cs

### DIFF
--- a/samples/Samples/Sample08_Polymorphism.cs
+++ b/samples/Samples/Sample08_Polymorphism.cs
@@ -56,11 +56,7 @@ namespace Samples
 			using ( var buffer = new MemoryStream() )
 			{
 				serializer.Pack(
-					buffer, new PolymorphicHolder
-					{
-						WithRuntimeType = new FileObject { Path = "/path/to/file" },
-						WithKnownType = new DirectoryObject { Path = "/path/to/dir/" }
-					}
+					buffer, rootObject	
 				);
 
 				buffer.Position = 0;


### PR DESCRIPTION
rootObject was initiated but not used, instead duplicate code was used to re-create the same object.