### PR TITLE
Solve 'System.Private.Uri' vulnerability

### DIFF
--- a/src/MsgPack/MsgPack.csproj
+++ b/src/MsgPack/MsgPack.csproj
@@ -58,9 +58,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="NETStandard.Library" Version="2.0.0" />
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
-    <PackageReference Include="System.Numerics.Vectors" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.3.0" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.6.0" />
+    <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsXamarin)' == 'true'">
     <PackageReference Include="NETStandard.Library" Version="2.0.0" />


### PR DESCRIPTION
`MsgPack.Cli` has a `.csproj` kinda like this:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>netstandard2.0</TargetFramework>
    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
    <OutputType>Exe</OutputType>
    <LangVersion>latest</LangVersion>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="System.Numerics.Vectors" Version="4.3.0" />
    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
    <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.3.0" />
  </ItemGroup>

</Project>
```

When I run `dotnet build *.sln --no-incremental`, I get this:
```sh
Restore succeeded with 3 warning(s) in 1,0s
    C:\Users\Administrator\Desktop\Testando\Testando.csproj : warning NU1903: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-5f2m-466j-3848
    C:\Users\Administrator\Desktop\Testando\Testando.csproj : warning NU1902: Package 'System.Private.Uri' 4.3.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-x5qj-9vmx-7g6g
    C:\Users\Administrator\Desktop\Testando\Testando.csproj : warning NU1903: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-xhfc-grories/GHSA-xhfc-gr8f-ffwc
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  Testando succeeded with 3 warning(s) (0,3s) → bin\Debug\netstandard2.0\Testando.dll
    C:\Users\Administrator\Desktop\Testando\Testando.csproj : warning NU1903: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-5f2m-466j-3848
    C:\Users\Administrator\Desktop\Testando\Testando.csproj : warning NU1902: Package 'System.Private.Uri' 4.3.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-x5qj-9vmx-7g6g
    C:\Users\Administrator\Desktop\Testando\Testando.csproj : warning NU1903: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-xhfc-gr8f-ffwc

Build succeeded with 6 warning(s) in 1,6s
```

But when I update the dependencies:
```xml
    <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
    <PackageReference Include="System.Reflection.Emit" Version="4.6.0" />
    <PackageReference Include="System.Reflection.Emit.LightWeight" Version="4.6.0" />
```

The `dotnet build *.sln --no-incremental` runs without warnings:
```sh
Restore complete (0,5s)
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  Testando succeeded (0,3s) → bin\Debug\netstandard2.0\Testando.dll

Build succeeded in 1,1s
```

Solves https://github.com/advisories/GHSA-5f2m-466j-3848, https://github.com/advisories/GHSA-x5qj-9vmx-7g6g, https://github.com/advisories/GHSA-xhfc-gr8f-ffwc
